### PR TITLE
Address Point Match Check

### DIFF
--- a/config/configuration.json
+++ b/config/configuration.json
@@ -16,7 +16,7 @@
 
   },
   "AddressPointMatchCheck": {
-    "bounds.distance": 5,
+    "bounds.size": 25.0,
     "challenge": {
       "description": "Tasks contain nodes which either have no street name or incorrect street names",
       "blurb": "Nodes without street names, or with incorrect street names",

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -16,7 +16,7 @@
 
   },
   "AddressPointMatchCheck": {
-    "bounds.size": 250.0,
+    "bounds.size": 150.0,
     "challenge": {
       "description": "Tasks contain nodes which either have no street name or incorrect street names",
       "blurb": "Nodes without street names, or with incorrect street names",

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -109,7 +109,7 @@
     }
   },
   "SelfIntersectingPolylineCheck": {
-    "tags.filter": "highway->*|waterway->*|building->*",
+    "tags.filter":"highway->*&highway->!construction&highway->!footway&highway->!path|building->*",
     "challenge": {
       "description": "Verify that the same Polyline does not intersect itself at any point.",
       "blurb": "Modify Polylines such that they do not self intersect.",

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -15,6 +15,16 @@
   "OrphanNodeCheck": {
 
   },
+  "AddressPointMatchCheck": {
+    "bounds.distance": 5,
+    "challenge": {
+      "description": "Tasks contain nodes which either have no street name or incorrect street names",
+      "blurb": "Nodes without street names, or with incorrect street names",
+      "instruction": "Open your favorite editor and edit the node street names",
+      "difficulty": "EASY",
+      "defaultPriority": "LOW",
+    }
+  },
   "BuildingRoadIntersectionCheck": {
     "challenge": {
       "description": "Tasks contain buildings which intersect with surrounding roads",

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -16,13 +16,13 @@
 
   },
   "AddressPointMatchCheck": {
-    "bounds.size": 25.0,
+    "bounds.size": 250.0,
     "challenge": {
       "description": "Tasks contain nodes which either have no street name or incorrect street names",
       "blurb": "Nodes without street names, or with incorrect street names",
       "instruction": "Open your favorite editor and edit the node street names",
       "difficulty": "EASY",
-      "defaultPriority": "LOW",
+      "defaultPriority": "LOW"
     }
   },
   "BuildingRoadIntersectionCheck": {
@@ -109,8 +109,6 @@
     }
   },
   "RoundaboutValenceCheck": {
-    "connections.minimum": 2.0,
-    "connections.maximum": 14.0,
     "challenge": {
       "description": "Verify that the valence of the roundabout is sensible.",
       "blurb": "Modify Polyline intersections with the roundabout edges",

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -109,6 +109,8 @@
     }
   },
   "RoundaboutValenceCheck": {
+    "connections.minimum": 2.0,
+    "connections.maximum": 14.0,
     "challenge": {
       "description": "Verify that the valence of the roundabout is sensible.",
       "blurb": "Modify Polyline intersections with the roundabout edges",

--- a/docs/checks/addressPointMatch.md
+++ b/docs/checks/addressPointMatch.md
@@ -1,18 +1,110 @@
 # Address Point Match Check
 
 #### Description
-
-This check identifies cases of improperly tagged street names (addr:street). This check includes
-cases where the street name has not been specified or if it has the incorrect street name. Due to
-the fact that we cannot account for different geocoding techniques that may exist in different parts
-of the world, we operate under the assumption that the nearest street to a given address location
-should be the street name tagged.
+This check identifies Point objects in OSM that have a specified street number (addr:housenumber) 
+but no specified street name (addr:street). No specified street name refers to either having a null
+value for the street name key, or no street name key present at all.
 
 #### Live Example
-
+The following examples illustrate two cases where a Point has a street number but no street name
+in its tags.
+1) This Point [id:977597085](https://www.openstreetmap.org/node/977597085) has a street number but 
+no street name specified in the address.
+2) This Point [id:4552330391](https://www.openstreetmap.org/node/4552330391) has a street number but
+no street name specified in the address.
 
 #### Code Review
+In [Atlas](https://github.com/osmlab/atlas), OSM elements are represented as Edges, Points, Lines, 
+Nodes & Relations; in our case, we’re are looking at [Points](https://github.com/osmlab/atlas/blob/dev/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Point.java)
+with specified street numbers but no street name.
 
+Our first goal is to validate the incoming Atlas object. Valid features for this check will satisfy
+the following conditions:
+* Must be a valid Point object
+* Must have a street number tag not equal to null
+* Must have a street name tag equal to null OR not have the street name key present at all
+
+```java
+ @Override
+    public boolean validCheckForObject(final AtlasObject object)
+    {
+        // Object is an instance of Point
+        return object instanceof Point
+                // And has a street number specified
+                && object.getTag(ADDRESS_STREET_NUMBER_KEY).isPresent()
+                // And if the street name key has a value of null
+                && (!object.getTag(POINT_STREET_NAME_KEY).isPresent()
+                    // Or if the street name key is not present
+                    || !object.getTags().containsKey(POINT_STREET_NAME_KEY));
+    }
+```
+
+After the preliminary filtering of features, we need to find candidates for populating each feature's
+missing street name. We do this by drawing a bounding box, leveraging the [`boxAround()`](https://github.com/osmlab/atlas/blob/dev/src/main/java/org/openstreetmap/atlas/geography/Location.java), 
+around the Point of interest using a configurable bounds size parameter. This value is set to a 
+default of 150 meters. Using these bounds, we can consider other Points that fall inside the bounds 
+that have a specified street number and street name using [`pointsWithin()`](https://github.com/osmlab/atlas/blob/dev/src/main/java/org/openstreetmap/atlas/geography/atlas/Atlas.java).
+If there are no other Points found within this bounding box, we next look at edges within or which 
+intersect with our bounding box using [`edgesIntersecting()`](https://github.com/osmlab/atlas/blob/dev/src/main/java/org/openstreetmap/atlas/geography/atlas/Atlas.java).
+If there are no Points or Edges within or intersecting our bounds, we still flag the problematic
+Point feature but with a specific instruction message indicating that no candidate street names were found.
+Otherwise, we flag the Point and list a Set of unique candidate street names in the instructions.
+
+```java
+ @Override
+    protected Optional<CheckFlag> flag(final AtlasObject object)
+    {
+        final Point point = (Point) object;
+        // Get a bounding box around the Point of interest
+        final Rectangle box = point.getLocation().boxAround(boundsSize);
+
+        // Get all Points inside the bounding box
+        Iterable<Point> interiorPoints = point.getAtlas().pointsWithin(box);
+        // Convert the Iterable into a Stream for filtering
+        Stream<Point> pointStream = StreamSupport.stream(interiorPoints.spliterator(), false);
+        // Remove Points that have null as their street name as they cannot be candidates for
+        // a street for the Point of interest
+        Set<Point> points = pointStream.filter(interiorPoint -> interiorPoint.getTag(POINT_STREET_NAME_KEY).isPresent())
+                .collect(Collectors.toSet());
+
+        // Get all Edges that intersect or are contained within the bounding box
+        Iterable<Edge> interiorEdges = point.getAtlas().edgesIntersecting(box);
+        // Convert the Iterable into a Stream for filtering
+        Stream<Edge> edgeStream = StreamSupport.stream(interiorEdges.spliterator(), false);
+        // Remove Edge that have null as their street name as they cannot be candidates for
+        // a street for the Point of interest
+        Set<Edge> edges = edgeStream.filter(interiorEdge -> interiorEdge.getTag(EDGE_STREET_NAME_KEY).isPresent())
+                .collect(Collectors.toSet());
+
+        Set<String> streetNameList = new HashSet<>();
+
+        // If there are no Points or Edges in the bounding box
+        if (points.isEmpty() && edges.isEmpty())
+        {
+            // Flag Point with instruction indicating that there are are no suggestions
+            return Optional.of(this.createFlag(point,
+                    this.getLocalizedInstruction(1, point.getOsmIdentifier())));
+        }
+        // If there are Points in the bounding box
+        else if (!points.isEmpty())
+        {
+            // Add all interior Point street names to the list of candidate street names
+            points.forEach(interiorPoint -> streetNameList
+                    .add(interiorPoint.getTags().get(POINT_STREET_NAME_KEY)));
+
+        }
+        // If there are Edges intersecting or contained by the bounding box
+        else
+        {
+            // Add all interior Edge street names to the list of candidate street names
+            edges.forEach(interiorEdge -> streetNameList
+                    .add(interiorEdge.getTags().get(EDGE_STREET_NAME_KEY)));
+        }
+
+        return Optional.of(this.createFlag(point,
+                this.getLocalizedInstruction(0, point.getOsmIdentifier(), streetNameList)));
+    }
+```
 
 To learn more about the code, please look at the comments in the source code for the check.
 [AddressPointMatchCheck.java](../../src/main/java/org/openstreetmap/atlas/checks/validation/points/AddressPointMatchCheck.java)

--- a/docs/checks/addressPointMatch.md
+++ b/docs/checks/addressPointMatch.md
@@ -1,0 +1,18 @@
+# Address Point Match Check
+
+#### Description
+
+This check identifies cases of improperly tagged street names (addr:street). This check includes
+cases where the street name has not been specified or if it has the incorrect street name. Due to
+the fact that we cannot account for different geocoding techniques that may exist in different parts
+of the world, we operate under the assumption that the nearest street to a given address location
+should be the street name tagged.
+
+#### Live Example
+
+
+#### Code Review
+
+
+To learn more about the code, please look at the comments in the source code for the check.
+[AddressPointMatchCheck.java](../../src/main/java/org/openstreetmap/atlas/checks/validation/points/AddressPointMatchCheck.java)

--- a/src/main/java/org/openstreetmap/atlas/checks/flag/CheckFlag.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/flag/CheckFlag.java
@@ -134,7 +134,14 @@ public class CheckFlag implements Iterable<Location>, Located, Serializable
     {
         if (object instanceof AtlasItem)
         {
-            this.flaggedObjects.add(new FlaggedPolyline(object));
+            if (object instanceof LocationItem)
+            {
+                this.flaggedObjects.add(new FlaggedPoint(((LocationItem) object).getLocation()));
+            }
+            else
+            {
+                this.flaggedObjects.add(new FlaggedPolyline(object));
+            }
         }
     }
 
@@ -168,8 +175,8 @@ public class CheckFlag implements Iterable<Location>, Located, Serializable
      */
     public void addObject(final AtlasObject object, final String instruction)
     {
-        addObject(object);
-        addInstruction(instruction);
+        this.addObject(object);
+        this.addInstruction(instruction);
     }
 
     /**
@@ -180,14 +187,7 @@ public class CheckFlag implements Iterable<Location>, Located, Serializable
      */
     public void addObjects(final Iterable<AtlasObject> objects)
     {
-        Iterables.stream(objects).filter(object -> object instanceof AtlasItem).map(item ->
-        {
-            if (item instanceof LocationItem)
-            {
-                return new FlaggedPoint(((LocationItem) item).getLocation());
-            }
-            return new FlaggedPolyline(item);
-        }).forEach(this.flaggedObjects::add);
+        Iterables.stream(objects).forEach(this::addObject);
     }
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/SelfIntersectingPolylineCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/SelfIntersectingPolylineCheck.java
@@ -1,10 +1,12 @@
 package org.openstreetmap.atlas.checks.validation.intersections;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
+import org.openstreetmap.atlas.checks.atlas.predicates.TagPredicates;
 import org.openstreetmap.atlas.checks.base.BaseCheck;
 import org.openstreetmap.atlas.checks.flag.CheckFlag;
 import org.openstreetmap.atlas.checks.validation.GeometryValidator;
@@ -12,10 +14,13 @@ import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.geography.Location;
 import org.openstreetmap.atlas.geography.PolyLine;
 import org.openstreetmap.atlas.geography.Polygon;
+import org.openstreetmap.atlas.geography.Segment;
 import org.openstreetmap.atlas.geography.atlas.items.Area;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
 import org.openstreetmap.atlas.geography.atlas.items.Edge;
 import org.openstreetmap.atlas.geography.atlas.items.Line;
+import org.openstreetmap.atlas.tags.WaterwayTag;
+import org.openstreetmap.atlas.tags.annotations.validation.Validators;
 import org.openstreetmap.atlas.utilities.configuration.Configuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,15 +30,23 @@ import org.slf4j.LoggerFactory;
  * {@link Edge}s and {@link Line}s. Both shape point and non-shape point intersections are flagged.
  *
  * @author mgostintsev
+ * @author dbaah
  */
 public class SelfIntersectingPolylineCheck extends BaseCheck<Long>
 {
-    private static final String INSTRUCTION_SHORT = "Self-intersecting polyline for feature {0,number,#}";
-    private static final String INSTRUCTION_LONG = INSTRUCTION_SHORT + " at {1}";
-    private static final List<String> FALLBACK_INSTRUCTIONS = Arrays.asList(INSTRUCTION_SHORT,
-            INSTRUCTION_LONG);
+    private static final String AREA_INSTRUCTION = "Feature {0,number,#} has invalid geometry at {1}";
+    private static final String POLYLINE_BUILDING_INSTRUCTION = "Feature {0,number,#} is a incomplete "
+            + "building at {1}";
+
+    private static final String DUPLICATE_EDGE_INSTRUCTION = "Feature {0,number,#} has a duplicate "
+            + "Edge at {1}";
+    private static final String POLYLINE_INSTRUCTION = "Self-intersecting polyline for feature "
+            + "{0,number,#} at {1}";
+    private static final List<String> FALLBACK_INSTRUCTIONS = Arrays.asList(POLYLINE_INSTRUCTION,
+            AREA_INSTRUCTION, POLYLINE_BUILDING_INSTRUCTION, DUPLICATE_EDGE_INSTRUCTION);
     private static final Logger logger = LoggerFactory
             .getLogger(SelfIntersectingPolylineCheck.class);
+    public static final Integer THREE = 3;
     private static final long serialVersionUID = 2722288442633787006L;
 
     /**
@@ -61,27 +74,40 @@ public class SelfIntersectingPolylineCheck extends BaseCheck<Long>
     @Override
     public boolean validCheckForObject(final AtlasObject object)
     {
-        return object instanceof Edge && ((Edge) object).isMasterEdge() || object instanceof Area
-                || object instanceof Line;
+        // Master edges excluding ineligible highway tags
+        return object instanceof Edge && ((Edge) object).isMasterEdge()
+                // Areas
+                || object instanceof Area
+                // Lines excluding ineligible highway tags
+                || object instanceof Line
+                        // Exclude waterway tags
+                        && !Validators.hasValuesFor(object, WaterwayTag.class);
     }
 
     @Override
     protected Optional<CheckFlag> flag(final AtlasObject object)
     {
         final Optional<CheckFlag> response;
+        final int localizedInstructionIndex;
 
         final PolyLine polyline;
         if (object instanceof Edge)
         {
             polyline = ((Edge) object).asPolyLine();
+            // Send building instructions if building tag exists
+            localizedInstructionIndex = (TagPredicates.IS_BUILDING.test(object)) ? 2 : 0;
         }
         else if (object instanceof Line)
         {
             polyline = ((Line) object).asPolyLine();
+            // Send building instructions if building tag exists
+            localizedInstructionIndex = (TagPredicates.IS_BUILDING.test(object)) ? 2 : 0;
         }
         else if (object instanceof Area)
         {
             polyline = ((Area) object).asPolygon();
+            // Send duplicate Edge instructions if duplicate Edges exist
+            localizedInstructionIndex = hasDuplicateEdges(polyline) ? THREE : 1;
         }
         else
         {
@@ -95,8 +121,8 @@ public class SelfIntersectingPolylineCheck extends BaseCheck<Long>
         {
             final CheckFlag flag = new CheckFlag(Long.toString(object.getIdentifier()));
             flag.addObject(object);
-            flag.addInstruction(this.getLocalizedInstruction(1, object.getOsmIdentifier(),
-                    selfIntersections.toString()));
+            flag.addInstruction(this.getLocalizedInstruction(localizedInstructionIndex,
+                    object.getOsmIdentifier(), selfIntersections.toString()));
             selfIntersections.forEach(flag::addPoint);
             response = Optional.of(flag);
         }
@@ -128,7 +154,7 @@ public class SelfIntersectingPolylineCheck extends BaseCheck<Long>
             if (!isJtsValid)
             {
                 response = Optional.of(createFlag(object,
-                        this.getLocalizedInstruction(0, object.getOsmIdentifier())));
+                        this.getLocalizedInstruction(localizedInstructionIndex)));
             }
             else
             {
@@ -143,5 +169,37 @@ public class SelfIntersectingPolylineCheck extends BaseCheck<Long>
     protected List<String> getFallbackInstructions()
     {
         return FALLBACK_INSTRUCTIONS;
+    }
+
+    /**
+     * Returns true if adjacent {@link Edge} has identical lat,lng sequences
+     *
+     * @param polyline
+     *            the {@link PolyLine} being examined
+     * @return {@code true} if the any set of adjacent edges have identical geometries
+     */
+    private boolean hasDuplicateEdges(final PolyLine polyline)
+    {
+        final List<Segment> segments = polyline.segments();
+        final List<Segment> duplicates = new ArrayList<>();
+
+        // Loop through Polyline Segments
+        for (int i = 0; i < segments.size(); i++)
+        {
+            final Segment segment = segments.get(i);
+            final int adjacentEdge = i + 2;
+
+            // Check if segment exists elsewhere in List
+            if (segments.indexOf(segment) != segments.lastIndexOf(segment))
+            {
+                // If adjacent segment is the same value as our current, duplicate exists
+                if (adjacentEdge < segments.size() && segment.equals(segments.get(adjacentEdge)))
+                {
+                    duplicates.add(segment);
+                }
+            }
+        }
+
+        return duplicates.size() > 0;
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SignPostCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SignPostCheck.java
@@ -1,54 +1,75 @@
 package org.openstreetmap.atlas.checks.validation.linear.edges;
 
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Predicate;
 
+import org.apache.directory.api.util.Strings;
 import org.openstreetmap.atlas.checks.atlas.predicates.TypePredicates;
 import org.openstreetmap.atlas.checks.base.BaseCheck;
 import org.openstreetmap.atlas.checks.flag.CheckFlag;
+import org.openstreetmap.atlas.geography.Heading;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
 import org.openstreetmap.atlas.geography.atlas.items.Edge;
+import org.openstreetmap.atlas.geography.atlas.items.Node;
 import org.openstreetmap.atlas.tags.DestinationTag;
 import org.openstreetmap.atlas.tags.HighwayTag;
 import org.openstreetmap.atlas.tags.annotations.validation.Validators;
+import org.openstreetmap.atlas.tags.filters.TaggableFilter;
 import org.openstreetmap.atlas.utilities.configuration.Configuration;
+import org.openstreetmap.atlas.utilities.scalars.Angle;
 import org.openstreetmap.atlas.utilities.scalars.Distance;
 
 /**
- * The SignPostCheck is used to help identify segments that are missing the proper tagging for sign
- * posts. The basic logic of the check is to first find all motorway and trunk edges which have link
- * edges departing them. Once you have identified these candidates a flag is thrown if one or both
- * of the following conditions are met.
+ * This check is used to help identify segments that are missing the proper tagging for sign posts.
+ * The basic logic of the check is to first find all edges with given filter with on and off ramps.
+ * Once ramps are identified and filtered, a flag is thrown if one or both of the following
+ * conditions are met.
  * <p>
- * 1) The shared node is missing the highway=motorway_junction tag<br>
- * 2) The exiting link edge is missing the destination tag<br>
+ * 1) The starting node for the ramp is missing the highway=motorway_junction tag<br>
+ * 2) The ramp road is missing the destination tag<br>
  * <p>
- * If either of these cases is true and the link edge is over a certain length then a flag is
- * signalled.
+ * If either of these cases is true and ramp is over a certain length then a flag is created.
  *
  * @author ericgodwin
+ * @author mkalender
  */
 public class SignPostCheck extends BaseCheck<String>
 {
     private static final long serialVersionUID = 8042255121118115024L;
 
     // Instruction
-    private static final String INSTRUCTION = "Junction node is missing the following tags: {0}.";
-    private static final List<String> FALLBACK_INSTRUCTIONS = Arrays.asList(INSTRUCTION);
+    private static final String NODE_INSTRUCTION = "Junction node {0,number,#} is missing the following tags: {1}.";
+    private static final String EDGE_INSTRUCTION = "Way {0,number,#} ({1}) is missing the following tags: {2}.";
+    private static final List<String> FALLBACK_INSTRUCTIONS = Arrays.asList(NODE_INSTRUCTION,
+            EDGE_INSTRUCTION);
+    private static final String OFF_RAMP_KEY = "off-ramp";
+    private static final String ON_RAMP_KEY = "on-ramp";
 
-    // Predicate defining the type of outbound links we are looking for.
-    private static final Predicate<Edge> LINK_PREDICATE = edge -> edge
-            .highwayTag() == HighwayTag.MOTORWAY_LINK || edge.highwayTag() == HighwayTag.TRUNK_LINK;
+    // Default values for configurable settings
+    private static final double DISTANCE_MINIMUM_METERS_DEFAULT = 50;
+    private static final String SOURCE_EDGE_FILTER_DEFAULT = "highway->motorway,trunk";
+    private static final String RAMP_FILTER_DEFAULT = "highway->motorway,motorway_link,trunk,trunk_link";
+    private static final double RAMP_ANGLE_DIFFERENCE_DEFAULT = 30;
 
-    // The default minimum link length which will trigger the check.
-    public static final double DISTANCE_MINIMUM_METERS_DEFAULT = 50;
+    // Maximum number of hops while collecting ramp edges
+    private static final int MAX_EDGE_COUNT_FOR_RAMP = 5;
 
     // The minimum link length to examine.
     private final Distance minimumLinkLength;
+
+    // A filter to filter source edges for flagging
+    private final TaggableFilter sourceEdgeFilter;
+
+    // A filter to filter ramp edges
+    private final TaggableFilter rampEdgeFilter;
+
+    // A tag to differentiate ramps from roads with the same classification
+    private final String rampDifferentiatorTag;
+
+    // Maximum angle difference between ramp edges
+    private final Angle rampAngleDifference;
 
     /**
      * The default constructor that must be supplied. The Atlas Checks framework will generate the
@@ -64,10 +85,18 @@ public class SignPostCheck extends BaseCheck<String>
 
         this.minimumLinkLength = configurationValue(configuration, "linkLength.minimum.meters",
                 DISTANCE_MINIMUM_METERS_DEFAULT, Distance::meters);
+        this.sourceEdgeFilter = configurationValue(configuration, "source.filter",
+                SOURCE_EDGE_FILTER_DEFAULT, value -> new TaggableFilter(value));
+        this.rampEdgeFilter = configurationValue(configuration, "ramp.filter", RAMP_FILTER_DEFAULT,
+                value -> new TaggableFilter(value));
+        this.rampDifferentiatorTag = configurationValue(configuration, "ramp.differentiator.tag",
+                null);
+        this.rampAngleDifference = configurationValue(configuration,
+                "ramp.angle.difference.degrees", RAMP_ANGLE_DIFFERENCE_DEFAULT, Angle::degrees);
     }
 
     /**
-     * This function will validate if the supplied atlas object is valid for the check.
+     * Validates if the supplied {@link AtlasObject} is valid for the check.
      *
      * @param object
      *            the atlas object supplied by the Atlas-Checks framework for evaluation
@@ -76,8 +105,7 @@ public class SignPostCheck extends BaseCheck<String>
     @Override
     public boolean validCheckForObject(final AtlasObject object)
     {
-        return TypePredicates.IS_EDGE.test(object) && Validators.isOfType(object, HighwayTag.class,
-                HighwayTag.MOTORWAY, HighwayTag.TRUNK, HighwayTag.PRIMARY, HighwayTag.PRIMARY_LINK);
+        return TypePredicates.IS_EDGE.test(object) && this.sourceEdgeFilter.test(object);
     }
 
     /**
@@ -91,45 +119,64 @@ public class SignPostCheck extends BaseCheck<String>
     protected Optional<CheckFlag> flag(final AtlasObject object)
     {
         final Edge edge = (Edge) object;
-        final Set<String> missingTags = new HashSet<String>();
-        final Set<AtlasObject> offendingObjects = new HashSet<AtlasObject>();
+        final HighwayTag highwayTag = edge.highwayTag();
+        final CheckFlag flag = new CheckFlag(this.getTaskIdentifier(object));
 
-        // First find any motorway_link edges going out of the edge
-        edge.outEdges().stream().filter(LINK_PREDICATE).forEach(outEdge ->
-        {
-            // Let's ignore really short segments as they are often connectors
-            // between doubly digitized trunk roads.
-            if (outEdge.length().isGreaterThan(this.minimumLinkLength))
-            {
-                // Check to see if the node leaving the mainline is missing the
-                // junction tag
-                if (!Validators.isOfType(outEdge.start(), HighwayTag.class,
-                        HighwayTag.MOTORWAY_JUNCTION))
+        // First find off ramps
+        edge.end().outEdges().stream()
+                .filter(connectedEdge -> isPossiblyRamp(edge, highwayTag, connectedEdge))
+                .forEach(outEdge ->
                 {
-                    missingTags.add(String.format("%s=%s", HighwayTag.KEY,
-                            HighwayTag.MOTORWAY_JUNCTION.getTagValue()));
-                    offendingObjects.add(outEdge.start());
-                }
+                    // Check to see if start node is missing junction tag
+                    final Node start = outEdge.start();
+                    if (!Validators.isOfType(start, HighwayTag.class, HighwayTag.MOTORWAY_JUNCTION))
+                    {
+                        flag.addInstruction(this.getLocalizedInstruction(0,
+                                start.getOsmIdentifier(), String.format("%s=%s", HighwayTag.KEY,
+                                        HighwayTag.MOTORWAY_JUNCTION.getTagValue())));
+                        flag.addObject(start);
+                    }
 
-                // See if the out edge has the destination tag.
-                if (!outEdge.getTag(DestinationTag.KEY).isPresent())
+                    // Check if edge is missing destination tag
+                    if (!outEdge.getTag(DestinationTag.KEY).isPresent())
+                    {
+                        flag.addInstruction(this.getLocalizedInstruction(1,
+                                outEdge.getOsmIdentifier(), OFF_RAMP_KEY, DestinationTag.KEY));
+                        flag.addObject(outEdge);
+                    }
+                });
+
+        // Then repeat the work for on ramps
+        edge.start().inEdges().stream()
+                .filter(connectedEdge -> isPossiblyRamp(edge, highwayTag, connectedEdge))
+                .forEach(inEdge ->
                 {
-                    missingTags.add(DestinationTag.KEY);
+                    // Find the source of in-ramp
+                    final Edge rampEdge = findFirstRampEdge(inEdge);
 
-                    // Instead of adding the edge we are adding the node so
-                    // that a single point in the task is highlighted.
-                    offendingObjects.add(outEdge.start());
-                }
-            }
-        });
+                    // Check to see if start node is missing junction tag
+                    final Node start = rampEdge.start();
+                    if (!Validators.isOfType(start, HighwayTag.class, HighwayTag.MOTORWAY_JUNCTION))
+                    {
+                        flag.addInstruction(this.getLocalizedInstruction(0,
+                                start.getOsmIdentifier(), String.format("%s=%s", HighwayTag.KEY,
+                                        HighwayTag.MOTORWAY_JUNCTION.getTagValue())));
+                        flag.addObject(start);
+                    }
 
-        // If it has an out link edge make sure that the end node has the appropriate
-        // highway=motorway_junction tag.
-        if (!offendingObjects.isEmpty())
+                    // Check if edge is missing destination tag
+                    if (!rampEdge.getTag(DestinationTag.KEY).isPresent())
+                    {
+                        flag.addInstruction(this.getLocalizedInstruction(1,
+                                rampEdge.getOsmIdentifier(), ON_RAMP_KEY, DestinationTag.KEY));
+                        flag.addObject(rampEdge);
+                    }
+                });
+
+        // Return the flag if it has any flagged objects in it
+        if (!flag.getFlaggedObjects().isEmpty())
         {
-            final String instruction = this.getLocalizedInstruction(0,
-                    String.join(", ", missingTags));
-            return Optional.of(this.createFlag(offendingObjects, instruction));
+            return Optional.of(flag);
         }
 
         return Optional.empty();
@@ -139,5 +186,102 @@ public class SignPostCheck extends BaseCheck<String>
     protected List<String> getFallbackInstructions()
     {
         return FALLBACK_INSTRUCTIONS;
+    }
+
+    /**
+     * Given a final {@link Edge}, hops back and finds the first edge that was forming the ramp.
+     *
+     * @param finalEdge
+     *            {@link Edge} that is the last/final piece of the ramp
+     * @return {@link Edge} that possibly is the first {@link Edge} forming the ramp
+     */
+    private Edge findFirstRampEdge(final Edge finalEdge)
+    {
+        int count = 0;
+
+        // Go back and collect edges
+        Edge nextEdge = finalEdge;
+        while (count < MAX_EDGE_COUNT_FOR_RAMP)
+        {
+            count++;
+
+            // Break if edge has no heading
+            final Optional<Heading> initialHeading = nextEdge.asPolyLine().initialHeading();
+            if (!initialHeading.isPresent())
+            {
+                break;
+            }
+
+            // Collect in edges and make sure there is not more than one
+            final Set<Edge> inEdges = nextEdge.inEdges();
+            if (inEdges.isEmpty() || inEdges.size() > 1)
+            {
+                break;
+            }
+
+            // Find the edge that precedes nextEdge
+            final HighwayTag highwayTag = nextEdge.highwayTag();
+            final Edge precedingEdge = inEdges.iterator().next();
+
+            // Ignore if edge has a different classification
+            if (!highwayTag.isIdenticalClassification(precedingEdge.highwayTag()))
+            {
+                break;
+            }
+
+            // Break if given edge has no heading
+            final Optional<Heading> finalHeading = precedingEdge.asPolyLine().finalHeading();
+            if (!finalHeading.isPresent() || initialHeading.get().asPositiveAngle()
+                    .difference(finalHeading.get().asPositiveAngle())
+                    .isGreaterThan(this.rampAngleDifference))
+            {
+                break;
+            }
+
+            nextEdge = precedingEdge;
+        }
+
+        return nextEdge;
+    }
+
+    /**
+     * Returns if given a connected {@link Edge} is possibly a ramp entering or leaving source
+     * {@link Edge}.
+     *
+     * @param sourceEdge
+     *            Source {@link Edge}
+     * @param sourceHighwayTag
+     *            {@link HighwayTag} of the source {@link Edge}
+     * @param connectedEdge
+     *            Connected {@link Edge} to source {@link Edge}
+     * @return true if connected {@link Edge} is a ramp
+     */
+    private boolean isPossiblyRamp(final Edge sourceEdge, final HighwayTag sourceHighwayTag,
+            final Edge connectedEdge)
+    {
+        // Ignore if edge is failing to pass ramp filter and also ignore if it is short
+        if (!this.rampEdgeFilter.test(connectedEdge)
+                || !connectedEdge.length().isGreaterThan(this.minimumLinkLength))
+        {
+            return false;
+        }
+
+        // Different classification is a good indication for a ramp
+        if (!sourceHighwayTag.isIdenticalClassification(connectedEdge.highwayTag()))
+        {
+            return true;
+        }
+
+        // If ramp differentiator tag is supplied, then use it to differentiate same classification
+        // edges
+        if (this.rampDifferentiatorTag == null)
+        {
+            return true;
+        }
+
+        // Look for certain tag differences if edges have same highway tag
+        final String sourceTag = sourceEdge.tag(this.rampDifferentiatorTag);
+        final String rampTag = connectedEdge.tag(this.rampDifferentiatorTag);
+        return !(sourceTag == null && rampTag == null || Strings.equals(sourceTag, rampTag));
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/points/AddressPointMatchCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/points/AddressPointMatchCheck.java
@@ -1,32 +1,31 @@
 package org.openstreetmap.atlas.checks.validation.points;
 
+
 import com.google.common.collect.Iterables;
 import org.openstreetmap.atlas.checks.base.BaseCheck;
 import org.openstreetmap.atlas.checks.flag.CheckFlag;
-import org.openstreetmap.atlas.geography.PolyLine;
 import org.openstreetmap.atlas.geography.Rectangle;
-import org.openstreetmap.atlas.geography.atlas.Atlas;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
 import org.openstreetmap.atlas.geography.atlas.items.Edge;
 import org.openstreetmap.atlas.geography.atlas.items.Node;
+import org.openstreetmap.atlas.geography.atlas.items.Point;
 import org.openstreetmap.atlas.utilities.configuration.Configuration;
 import org.openstreetmap.atlas.utilities.scalars.Distance;
 
 import java.util.*;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 
 public class AddressPointMatchCheck extends BaseCheck
 {
     private static final long serialVersionUID = 1L;
-    public static final String WRONG_STREET_NAME_INSTRUCTIONS = "This node, {0,number,#}, has the "
-            + "incorrect street name tagged in the address. The street name should be {1}.";
-    public static final String NO_STREET_NAME_INSTRUCTIONS = "This node, {0,number,#}, has no "
-            + "street name tagged in the address. The street name should be {1}.";
+    public static final String NO_STREET_NAME_INSTRUCTIONS = "This node, {0,number,#}, has "
+            + "no street name specified in the address. The street name should likely "
+            + "be one of {1}.";
+    public static final String NO_SUGGESTED_NAMES_INSTRUCTIONS = "This node, {0,number,#}, has "
+            + "no street name specified in the address. No suggestions names were found.";
     private static final List<String> FALLBACK_INSTRUCTIONS = Arrays
-            .asList(WRONG_STREET_NAME_INSTRUCTIONS, NO_STREET_NAME_INSTRUCTIONS);
-    private static final String ADDRESS_STREET_KEY = "addr:street";
+            .asList(NO_STREET_NAME_INSTRUCTIONS, NO_SUGGESTED_NAMES_INSTRUCTIONS);
+    private static final String ADDRESS_STREET_NUMBER_KEY = "addr:housenumber";
+    private static final String STREET_NAME_KEY = "addr:street";
     private static final double BOUNDS_SIZE_DEFAULT = 25.0;
 
     private final Distance boundsSize;
@@ -39,13 +38,14 @@ public class AddressPointMatchCheck extends BaseCheck
     public AddressPointMatchCheck(final Configuration configuration)
     {
         super(configuration);
-        this.boundsSize = Distance.meters((Double) configurationValue(configuration, "bounds.size",
-                BOUNDS_SIZE_DEFAULT));
+        this.boundsSize = Distance.meters((Double) configurationValue(configuration,
+                "bounds.size", BOUNDS_SIZE_DEFAULT));
     }
 
     @Override public boolean validCheckForObject(final AtlasObject object)
     {
-        return object instanceof Node;
+        return object instanceof Point
+                && !object.getTags().containsKey(ADDRESS_STREET_NUMBER_KEY);
     }
 
     /**
@@ -59,61 +59,31 @@ public class AddressPointMatchCheck extends BaseCheck
         final Node node = (Node) object;
         // Get a bounding box around the Node of interest
         final Rectangle box = node.getLocation().boxAround(boundsSize);
-        double closestNodeDistance = Integer.MAX_VALUE;
-        Node closestNode = null;
 
-        // Try and find the closest Node to the Node of interest
-        getClosestNode(node, box, closestNode, closestNodeDistance);
+        Iterable<Node> interiorNodes = node.getAtlas().nodesWithin(box);
+        Iterable<Edge> interiorEdges = node.getAtlas().edgesIntersecting(box);
+        List<String> streetNameList = new ArrayList<>();
 
-
-
-
-        // If we have found the closest Node to the Node of interest (so it exists)
-        if (closestNode != null)
+        // If there are no nodes or edges in the bounding box
+        if (Iterables.isEmpty(interiorEdges) && Iterables.isEmpty(interiorEdges)) {
+            // Flag node with instruction indicating that there are are no suggestions
+            return Optional.of(this.createFlag(node, this.getLocalizedInstruction(1,
+                    node.getOsmIdentifier()));
+        }
+        else if (!Iterables.isEmpty(interiorNodes))
         {
-            // Flag the node with the proper street name in the MapRoulette instructions
+            interiorNodes.forEach(interiorNode ->
+                    streetNameList.add((interiorNode.getTags().get(STREET_NAME_KEY))));
+
+        }
+        else if (!Iterables.isEmpty(interiorEdges)){
+            interiorEdges.forEach(interiorEdge ->
+                    streetNameList.add((interiorEdge.getTags().get(STREET_NAME_KEY))));
+        }
+
+
             return Optional.of(this.createFlag(node, this.getLocalizedInstruction(0,
-                    node.getOsmIdentifier(), closestNode.getTag(ADDRESS_STREET_KEY))));
-        }
-        // If we haven't found a closest Node, then we need to check for streets that intersect
-        // With our bounding box
-
-
-        // If we haven't found an any Edges (or any Nodes), then flag the Node but state that we
-        // are not certain of the proper street name for that Node. The proper street name should
-        // be decided at the discretion of the editor
-        return Optional.of(this.createFlag(node, this.getLocalizedInstruction(1,
-                node.getOsmIdentifier())));
-    }
-
-    private Node getClosestNode(Node node, Rectangle boundingBox, Node closestNodeObj, double closestNodeDistanceVal) {
-        final Iterable<Node> interiorNodes = node.getAtlas().nodesWithin(boundingBox);
-
-        // If there are nodes within the bounding box (aside from the Node of interest
-        if (!Iterables.isEmpty(interiorNodes))
-        {
-            // For each node in the bounding box
-            for (Node interiorNode : interiorNodes)
-            {
-                // If node in the bounding box has a street name
-                if (interiorNode.getTags().containsKey(ADDRESS_STREET_KEY))
-                {
-                    PolyLine nodesAsPolyline = new PolyLine(node.getLocation(),
-                            interiorNode.getLocation());
-                    double betweenNodeDistance = nodesAsPolyline.length().asMeters();
-
-                    // If a interior Node has not yet been compared to the Node of interest
-                    // Or if the interior Node to the Node of interest distance is shorter
-                    // Than the closestNodeDistance
-                    if (closestNodeObj == null || closestNodeDistanceVal > betweenNodeDistance)
-                    {
-                        closestNodeObj = interiorNode;
-                        closestNodeDistanceVal = betweenNodeDistance;
-
-                    }
-                }
-            }
+                    node.getOsmIdentifier(), streetNameList)));
         }
     }
-
 }

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/points/AddressPointMatchCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/points/AddressPointMatchCheck.java
@@ -1,7 +1,10 @@
 package org.openstreetmap.atlas.checks.validation.points;
 
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
-import com.google.common.collect.Iterables;
 import org.openstreetmap.atlas.checks.base.BaseCheck;
 import org.openstreetmap.atlas.checks.flag.CheckFlag;
 import org.openstreetmap.atlas.geography.Rectangle;
@@ -12,7 +15,7 @@ import org.openstreetmap.atlas.geography.atlas.items.Point;
 import org.openstreetmap.atlas.utilities.configuration.Configuration;
 import org.openstreetmap.atlas.utilities.scalars.Distance;
 
-import java.util.*;
+import com.google.common.collect.Iterables;
 
 public class AddressPointMatchCheck extends BaseCheck
 {
@@ -25,12 +28,14 @@ public class AddressPointMatchCheck extends BaseCheck
     private static final List<String> FALLBACK_INSTRUCTIONS = Arrays
             .asList(NO_STREET_NAME_INSTRUCTIONS, NO_SUGGESTED_NAMES_INSTRUCTIONS);
     private static final String ADDRESS_STREET_NUMBER_KEY = "addr:housenumber";
-    private static final String STREET_NAME_KEY = "addr:street";
+    private static final String POINT_STREET_NAME_KEY = "addr:street";
+    private static final String EDGE_STREET_NAME_KEY ="name";
     private static final double BOUNDS_SIZE_DEFAULT = 25.0;
 
     private final Distance boundsSize;
 
-    @Override protected List<String> getFallbackInstructions()
+    @Override
+    protected List<String> getFallbackInstructions()
     {
         return FALLBACK_INSTRUCTIONS;
     }
@@ -38,52 +43,79 @@ public class AddressPointMatchCheck extends BaseCheck
     public AddressPointMatchCheck(final Configuration configuration)
     {
         super(configuration);
-        this.boundsSize = Distance.meters((Double) configurationValue(configuration,
-                "bounds.size", BOUNDS_SIZE_DEFAULT));
+        this.boundsSize = Distance.meters(
+                (Double) configurationValue(configuration, "bounds.size", BOUNDS_SIZE_DEFAULT));
     }
 
-    @Override public boolean validCheckForObject(final AtlasObject object)
+    @Override
+    public boolean validCheckForObject(final AtlasObject object)
     {
+        // Object is an instance of Point
         return object instanceof Point
-                && !object.getTags().containsKey(ADDRESS_STREET_NUMBER_KEY);
+                // And has a street number specified
+                && object.getTag(ADDRESS_STREET_NUMBER_KEY).isPresent()
+                && (!object.getTag(POINT_STREET_NAME_KEY).isPresent()
+                    || !object.getTags().containsKey(POINT_STREET_NAME_KEY));
     }
 
     /**
      * This is the actual function that will check to see whether the object needs to be flagged.
      *
-     * @param object the atlas object supplied by the Atlas-Checks framework for evaluation
+     * @param object
+     *            the atlas object supplied by the Atlas-Checks framework for evaluation
      * @return an optional {@link CheckFlag} object that
      */
-    @Override protected Optional<CheckFlag> flag(final AtlasObject object)
+    @Override
+    protected Optional<CheckFlag> flag(final AtlasObject object)
     {
-        final Node node = (Node) object;
-        // Get a bounding box around the Node of interest
-        final Rectangle box = node.getLocation().boxAround(boundsSize);
+        final Point point = (Point) object;
+        // Get a bounding box around the Point of interest
+        final Rectangle box = point.getLocation().boxAround(boundsSize);
 
-        Iterable<Node> interiorNodes = node.getAtlas().nodesWithin(box);
-        Iterable<Edge> interiorEdges = node.getAtlas().edgesIntersecting(box);
-        List<String> streetNameList = new ArrayList<>();
+        // Get all Points inside the bounding box
+        Iterable<Point> interiorPoints = point.getAtlas().pointsWithin(box);
+        // Convert the Iterable into a Stream for filtering
+        Stream<Point> pointStream = StreamSupport.stream(interiorPoints.spliterator(), false);
+        // Remove Points that have null as their street name as they cannot be candidates for
+        // a street for the Point of interest
+        Set<Point> points = pointStream.filter(interiorPoint -> interiorPoint.getTag(POINT_STREET_NAME_KEY).isPresent())
+                .collect(Collectors.toSet());
 
-        // If there are no nodes or edges in the bounding box
-        if (Iterables.isEmpty(interiorEdges) && Iterables.isEmpty(interiorEdges)) {
-            // Flag node with instruction indicating that there are are no suggestions
-            return Optional.of(this.createFlag(node, this.getLocalizedInstruction(1,
-                    node.getOsmIdentifier()));
-        }
-        else if (!Iterables.isEmpty(interiorNodes))
+        // Get all Edges that intersect or are contained within the bounding box
+        Iterable<Edge> interiorEdges = point.getAtlas().edgesIntersecting(box);
+        // Convert the Iterable into a Stream for filtering
+        Stream<Edge> edgeStream = StreamSupport.stream(interiorEdges.spliterator(), false);
+        // Remove Edge that have null as their street name as they cannot be candidates for
+        // a street for the Point of interest
+        Set<Edge> edges = edgeStream.filter(interiorEdge -> interiorEdge.getTag(EDGE_STREET_NAME_KEY).isPresent())
+                .collect(Collectors.toSet());
+
+        Set<String> streetNameList = new HashSet<>();
+
+        // If there are no Points or Edges in the bounding box
+        if (points.isEmpty() && edges.isEmpty())
         {
-            interiorNodes.forEach(interiorNode ->
-                    streetNameList.add((interiorNode.getTags().get(STREET_NAME_KEY))));
+            // Flag Point with instruction indicating that there are are no suggestions
+            return Optional.of(this.createFlag(point,
+                    this.getLocalizedInstruction(1, point.getOsmIdentifier())));
+        }
+        // If there are Points in the bounding box
+        else if (!points.isEmpty())
+        {
+            // Add all interior Point street names to the list of candidate street names
+            points.forEach(interiorPoint -> streetNameList
+                    .add((interiorPoint.getTags().get(POINT_STREET_NAME_KEY))));
 
         }
-        else if (!Iterables.isEmpty(interiorEdges)){
-            interiorEdges.forEach(interiorEdge ->
-                    streetNameList.add((interiorEdge.getTags().get(STREET_NAME_KEY))));
+        // If there are Edges intersecting or contained by the bounding box
+        else
+        {
+            // Add all interior Edge street names to the list of candidate street names
+            edges.forEach(interiorEdge -> streetNameList
+                    .add((interiorEdge.getTags().get(EDGE_STREET_NAME_KEY))));
         }
 
-
-            return Optional.of(this.createFlag(node, this.getLocalizedInstruction(0,
-                    node.getOsmIdentifier(), streetNameList)));
-        }
+        return Optional.of(this.createFlag(point,
+                this.getLocalizedInstruction(0, point.getOsmIdentifier(), streetNameList)));
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/points/AddressPointMatchCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/points/AddressPointMatchCheck.java
@@ -1,6 +1,10 @@
 package org.openstreetmap.atlas.checks.validation.points;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
@@ -10,12 +14,9 @@ import org.openstreetmap.atlas.checks.flag.CheckFlag;
 import org.openstreetmap.atlas.geography.Rectangle;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
 import org.openstreetmap.atlas.geography.atlas.items.Edge;
-import org.openstreetmap.atlas.geography.atlas.items.Node;
 import org.openstreetmap.atlas.geography.atlas.items.Point;
 import org.openstreetmap.atlas.utilities.configuration.Configuration;
 import org.openstreetmap.atlas.utilities.scalars.Distance;
-
-import com.google.common.collect.Iterables;
 
 /**
  * Tests for {@link AddressPointMatchCheck}
@@ -26,16 +27,20 @@ import com.google.common.collect.Iterables;
 public class AddressPointMatchCheck extends BaseCheck
 {
     private static final long serialVersionUID = 1L;
-    public static final String NO_STREET_NAME_INSTRUCTIONS = "This node, {0,number,#}, has "
+    public static final String NO_STREET_NAME_POINT_INSTRUCTIONS = "This node, {0,number,#}, has "
             + "no street name specified in the address. The street name should likely "
-            + "be one of {1}.";
+            + "be one of {1}. These names were derived from nearby Points.";
+    public static final String NO_STREET_NAME_EDGE_INSTRUCTIONS = "This node, {0,number,#}, has "
+            + "no street name specified in the address. The street name should likely "
+            + "be one of {1}. These names were derived from nearby Edges.";
     public static final String NO_SUGGESTED_NAMES_INSTRUCTIONS = "This node, {0,number,#}, has "
             + "no street name specified in the address. No suggestions names were found.";
-    private static final List<String> FALLBACK_INSTRUCTIONS = Arrays
-            .asList(NO_STREET_NAME_INSTRUCTIONS, NO_SUGGESTED_NAMES_INSTRUCTIONS);
+    private static final List<String> FALLBACK_INSTRUCTIONS = Arrays.asList(
+            NO_STREET_NAME_POINT_INSTRUCTIONS, NO_STREET_NAME_EDGE_INSTRUCTIONS,
+            NO_SUGGESTED_NAMES_INSTRUCTIONS);
     private static final String ADDRESS_STREET_NUMBER_KEY = "addr:housenumber";
     private static final String POINT_STREET_NAME_KEY = "addr:street";
-    private static final String EDGE_STREET_NAME_KEY ="name";
+    private static final String EDGE_STREET_NAME_KEY = "name";
     private static final double BOUNDS_SIZE_DEFAULT = 150.0;
 
     private final Distance boundsSize;
@@ -62,8 +67,8 @@ public class AddressPointMatchCheck extends BaseCheck
                 && object.getTag(ADDRESS_STREET_NUMBER_KEY).isPresent()
                 // And if the street name key has a value of null
                 && (!object.getTag(POINT_STREET_NAME_KEY).isPresent()
-                    // Or if the street name key is not present
-                    || !object.getTags().containsKey(POINT_STREET_NAME_KEY));
+                        // Or if the street name key is not present
+                        || !object.getTags().containsKey(POINT_STREET_NAME_KEY));
     }
 
     /**
@@ -81,31 +86,33 @@ public class AddressPointMatchCheck extends BaseCheck
         final Rectangle box = point.getLocation().boxAround(boundsSize);
 
         // Get all Points inside the bounding box
-        Iterable<Point> interiorPoints = point.getAtlas().pointsWithin(box);
+        final Iterable<Point> interiorPoints = point.getAtlas().pointsWithin(box);
         // Convert the Iterable into a Stream for filtering
-        Stream<Point> pointStream = StreamSupport.stream(interiorPoints.spliterator(), false);
+        final Stream<Point> pointStream = StreamSupport.stream(interiorPoints.spliterator(), false);
         // Remove Points that have null as their street name as they cannot be candidates for
         // a street for the Point of interest
-        Set<Point> points = pointStream.filter(interiorPoint -> interiorPoint.getTag(POINT_STREET_NAME_KEY).isPresent())
+        final Set<Point> points = pointStream
+                .filter(interiorPoint -> interiorPoint.getTag(POINT_STREET_NAME_KEY).isPresent())
                 .collect(Collectors.toSet());
 
         // Get all Edges that intersect or are contained within the bounding box
-        Iterable<Edge> interiorEdges = point.getAtlas().edgesIntersecting(box);
+        final Iterable<Edge> interiorEdges = point.getAtlas().edgesIntersecting(box);
         // Convert the Iterable into a Stream for filtering
-        Stream<Edge> edgeStream = StreamSupport.stream(interiorEdges.spliterator(), false);
+        final Stream<Edge> edgeStream = StreamSupport.stream(interiorEdges.spliterator(), false);
         // Remove Edge that have null as their street name as they cannot be candidates for
         // a street for the Point of interest
-        Set<Edge> edges = edgeStream.filter(interiorEdge -> interiorEdge.getTag(EDGE_STREET_NAME_KEY).isPresent())
+        final Set<Edge> edges = edgeStream
+                .filter(interiorEdge -> interiorEdge.getTag(EDGE_STREET_NAME_KEY).isPresent())
                 .collect(Collectors.toSet());
 
-        Set<String> streetNameList = new HashSet<>();
+        final Set<String> streetNameList = new HashSet<>();
 
         // If there are no Points or Edges in the bounding box
         if (points.isEmpty() && edges.isEmpty())
         {
             // Flag Point with instruction indicating that there are are no suggestions
             return Optional.of(this.createFlag(point,
-                    this.getLocalizedInstruction(1, point.getOsmIdentifier())));
+                    this.getLocalizedInstruction(2, point.getOsmIdentifier())));
         }
         // If there are Points in the bounding box
         else if (!points.isEmpty())
@@ -113,6 +120,8 @@ public class AddressPointMatchCheck extends BaseCheck
             // Add all interior Point street names to the list of candidate street names
             points.forEach(interiorPoint -> streetNameList
                     .add(interiorPoint.getTags().get(POINT_STREET_NAME_KEY)));
+            return Optional.of(this.createFlag(point,
+                    this.getLocalizedInstruction(0, point.getOsmIdentifier(), streetNameList)));
 
         }
         // If there are Edges intersecting or contained by the bounding box
@@ -121,9 +130,9 @@ public class AddressPointMatchCheck extends BaseCheck
             // Add all interior Edge street names to the list of candidate street names
             edges.forEach(interiorEdge -> streetNameList
                     .add(interiorEdge.getTags().get(EDGE_STREET_NAME_KEY)));
+            return Optional.of(this.createFlag(point,
+                    this.getLocalizedInstruction(1, point.getOsmIdentifier(), streetNameList)));
         }
 
-        return Optional.of(this.createFlag(point,
-                this.getLocalizedInstruction(0, point.getOsmIdentifier(), streetNameList)));
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/points/AddressPointMatchCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/points/AddressPointMatchCheck.java
@@ -62,7 +62,32 @@ public class AddressPointMatchCheck extends BaseCheck
         double closestNodeDistance = Integer.MAX_VALUE;
         Node closestNode = null;
 
-        final Iterable<Node> interiorNodes = node.getAtlas().nodesWithin(box);
+        // Try and find the closest Node to the Node of interest
+        getClosestNode(node, box, closestNode, closestNodeDistance);
+
+
+
+
+        // If we have found the closest Node to the Node of interest (so it exists)
+        if (closestNode != null)
+        {
+            // Flag the node with the proper street name in the MapRoulette instructions
+            return Optional.of(this.createFlag(node, this.getLocalizedInstruction(0,
+                    node.getOsmIdentifier(), closestNode.getTag(ADDRESS_STREET_KEY))));
+        }
+        // If we haven't found a closest Node, then we need to check for streets that intersect
+        // With our bounding box
+
+
+        // If we haven't found an any Edges (or any Nodes), then flag the Node but state that we
+        // are not certain of the proper street name for that Node. The proper street name should
+        // be decided at the discretion of the editor
+        return Optional.of(this.createFlag(node, this.getLocalizedInstruction(1,
+                node.getOsmIdentifier())));
+    }
+
+    private Node getClosestNode(Node node, Rectangle boundingBox, Node closestNodeObj, double closestNodeDistanceVal) {
+        final Iterable<Node> interiorNodes = node.getAtlas().nodesWithin(boundingBox);
 
         // If there are nodes within the bounding box (aside from the Node of interest
         if (!Iterables.isEmpty(interiorNodes))
@@ -80,24 +105,15 @@ public class AddressPointMatchCheck extends BaseCheck
                     // If a interior Node has not yet been compared to the Node of interest
                     // Or if the interior Node to the Node of interest distance is shorter
                     // Than the closestNodeDistance
-                    if (closestNode == null || closestNodeDistance > betweenNodeDistance)
+                    if (closestNodeObj == null || closestNodeDistanceVal > betweenNodeDistance)
                     {
-                        closestNode = interiorNode;
-                        closestNodeDistance = betweenNodeDistance;
+                        closestNodeObj = interiorNode;
+                        closestNodeDistanceVal = betweenNodeDistance;
 
                     }
                 }
             }
         }
-        if (closestNode == null)
-        {
-
-        }
-    }
-
-    protected Optional<String> getStreetName(AtlasObject closestFeature)
-    {
-        return closestFeature.getTag(ADDRESS_STREET_KEY);
     }
 
 }

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/points/AddressPointMatchCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/points/AddressPointMatchCheck.java
@@ -5,6 +5,7 @@ import org.openstreetmap.atlas.checks.base.BaseCheck;
 import org.openstreetmap.atlas.checks.flag.CheckFlag;
 import org.openstreetmap.atlas.geography.PolyLine;
 import org.openstreetmap.atlas.geography.Rectangle;
+import org.openstreetmap.atlas.geography.atlas.Atlas;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
 import org.openstreetmap.atlas.geography.atlas.items.Edge;
 import org.openstreetmap.atlas.geography.atlas.items.Node;
@@ -13,6 +14,8 @@ import org.openstreetmap.atlas.utilities.scalars.Distance;
 
 import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 public class AddressPointMatchCheck extends BaseCheck
 {
@@ -55,36 +58,36 @@ public class AddressPointMatchCheck extends BaseCheck
     {
         final Node node = (Node) object;
         final Rectangle box = node.getLocation().boxAround(Distance.meters(this.boundsDistance));
-        Node closestNode;
-        Edge closestEdge;
+               Map<Node, Double> nodeDistances;
+        Map<Edge, Double> edgeDistances;
+        double shortestDistance;
 
         if (!Iterables.isEmpty(node.getAtlas().nodesWithin(box))) {
-            closestNode = getClosestNode(node, box);
+            nodeDistances = getClosestNode(node, box);
+        } else if (!Iterables.isEmpty(node.getAtlas().edgesIntersecting(box))) {
+            edgeDistances = getClosestEdge(node, box);
         }
 
-        if (!Iterables.isEmpty(node.getAtlas().edgesIntersecting(box))) {
-            closestEdge = getClosestEdge(node, box);
-        }
+        // get the shortest distance from nodeDistances and store key,value
+        //get shortest distance from edgeDistances, compare to key,value and replace if less
 
-
-
+        //return the street address of node or edge which is closest
 
     }
 
-    protected String getStreetName(Node node)
+    protected Optional<String> getStreetName(AtlasObject closestFeature)
     {
-
+        return closestFeature.getTag(ADDRESS_STREET_KEY);
     }
 
-    protected Node getClosestNode(Node node, Rectangle bounds)
+    protected Map<Node, Double> nodeDistances (Node node, Rectangle bounds)
     {
         final Map<Node, Double> nodeDistances = new HashMap<>();
 
         // Gets all nodes within the bounds
         final Iterable<Node> interiorNodes = node.getAtlas().nodesWithin(bounds);
 
-        //
-        if (Iterables.isEmpty(interiorNodes))
+        if (!Iterables.isEmpty(interiorNodes))
         {
             for (Node interiorNode : interiorNodes)
             {
@@ -97,11 +100,11 @@ public class AddressPointMatchCheck extends BaseCheck
                 nodeDistances.put(interiorNode, distance);
             }
         }
+        return nodeDistances;
 
-        // return the key with minimum value in map
     }
 
-    protected Edge getClosestEdge(Node node, Rectangle bounds) {
+    protected Map<Edge, Double> getClosestEdge(Node node, Rectangle bounds) {
 
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/points/AddressPointMatchCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/points/AddressPointMatchCheck.java
@@ -1,0 +1,107 @@
+package org.openstreetmap.atlas.checks.validation.points;
+
+import com.google.common.collect.Iterables;
+import org.openstreetmap.atlas.checks.base.BaseCheck;
+import org.openstreetmap.atlas.checks.flag.CheckFlag;
+import org.openstreetmap.atlas.geography.PolyLine;
+import org.openstreetmap.atlas.geography.Rectangle;
+import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
+import org.openstreetmap.atlas.geography.atlas.items.Edge;
+import org.openstreetmap.atlas.geography.atlas.items.Node;
+import org.openstreetmap.atlas.utilities.configuration.Configuration;
+import org.openstreetmap.atlas.utilities.scalars.Distance;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class AddressPointMatchCheck extends BaseCheck
+{
+    private static final long serialVersionUID = 1L;
+    public static final String WRONG_STREET_NAME_INSTRUCTIONS = "This node, {0,number,#}, has the "
+            + "incorrect street name tagged in the address. The street name should be {1}.";
+    public static final String NO_STREET_NAME_INSTRUCTIONS = "This node, {0,number,#}, has no "
+            + "street name tagged in the address. The street name should be {1}.";
+    private static final List<String> FALLBACK_INSTRUCTIONS = Arrays
+            .asList(WRONG_STREET_NAME_INSTRUCTIONS, NO_STREET_NAME_INSTRUCTIONS);
+    private static final String ADDRESS_STREET_KEY = "addr:street";
+    private static final int BOUNDS_DISTANCE_DEFAULT = 5;
+
+    private final double boundsDistance;
+
+    @Override protected List<String> getFallbackInstructions()
+    {
+        return FALLBACK_INSTRUCTIONS;
+    }
+
+    public AddressPointMatchCheck(final Configuration configuration)
+    {
+        super(configuration);
+        this.boundsDistance = (double) configurationValue(configuration, "bounds.distance",
+                BOUNDS_DISTANCE_DEFAULT);
+    }
+
+    @Override public boolean validCheckForObject(final AtlasObject object)
+    {
+        return object instanceof Node;
+    }
+
+    /**
+     * This is the actual function that will check to see whether the object needs to be flagged.
+     *
+     * @param object the atlas object supplied by the Atlas-Checks framework for evaluation
+     * @return an optional {@link CheckFlag} object that
+     */
+    @Override protected Optional<CheckFlag> flag(final AtlasObject object)
+    {
+        final Node node = (Node) object;
+        final Rectangle box = node.getLocation().boxAround(Distance.meters(this.boundsDistance));
+        Node closestNode;
+        Edge closestEdge;
+
+        if (!Iterables.isEmpty(node.getAtlas().nodesWithin(box))) {
+            closestNode = getClosestNode(node, box);
+        }
+
+        if (!Iterables.isEmpty(node.getAtlas().edgesIntersecting(box))) {
+            closestEdge = getClosestEdge(node, box);
+        }
+
+
+
+
+    }
+
+    protected String getStreetName(Node node)
+    {
+
+    }
+
+    protected Node getClosestNode(Node node, Rectangle bounds)
+    {
+        final Map<Node, Double> nodeDistances = new HashMap<>();
+
+        // Gets all nodes within the bounds
+        final Iterable<Node> interiorNodes = node.getAtlas().nodesWithin(bounds);
+
+        //
+        if (Iterables.isEmpty(interiorNodes))
+        {
+            for (Node interiorNode : interiorNodes)
+            {
+                if (!interiorNode.getTags().containsKey(ADDRESS_STREET_KEY)) {
+                    continue;
+                }
+                PolyLine nodesAsPoly = new PolyLine(node.getLocation(), interiorNode.getLocation());
+                double distance = nodesAsPoly.length().asMeters();
+
+                nodeDistances.put(interiorNode, distance);
+            }
+        }
+
+        // return the key with minimum value in map
+    }
+
+    protected Edge getClosestEdge(Node node, Rectangle bounds) {
+
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/points/AddressPointMatchCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/points/AddressPointMatchCheck.java
@@ -17,6 +17,12 @@ import org.openstreetmap.atlas.utilities.scalars.Distance;
 
 import com.google.common.collect.Iterables;
 
+/**
+ * Tests for {@link AddressPointMatchCheck}
+ *
+ * @author savannahostrowski
+ */
+
 public class AddressPointMatchCheck extends BaseCheck
 {
     private static final long serialVersionUID = 1L;

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/points/AddressPointMatchCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/points/AddressPointMatchCheck.java
@@ -30,7 +30,7 @@ public class AddressPointMatchCheck extends BaseCheck
     private static final String ADDRESS_STREET_NUMBER_KEY = "addr:housenumber";
     private static final String POINT_STREET_NAME_KEY = "addr:street";
     private static final String EDGE_STREET_NAME_KEY ="name";
-    private static final double BOUNDS_SIZE_DEFAULT = 25.0;
+    private static final double BOUNDS_SIZE_DEFAULT = 150.0;
 
     private final Distance boundsSize;
 
@@ -54,7 +54,9 @@ public class AddressPointMatchCheck extends BaseCheck
         return object instanceof Point
                 // And has a street number specified
                 && object.getTag(ADDRESS_STREET_NUMBER_KEY).isPresent()
+                // And if the street name key has a value of null
                 && (!object.getTag(POINT_STREET_NAME_KEY).isPresent()
+                    // Or if the street name key is not present
                     || !object.getTags().containsKey(POINT_STREET_NAME_KEY));
     }
 
@@ -104,7 +106,7 @@ public class AddressPointMatchCheck extends BaseCheck
         {
             // Add all interior Point street names to the list of candidate street names
             points.forEach(interiorPoint -> streetNameList
-                    .add((interiorPoint.getTags().get(POINT_STREET_NAME_KEY))));
+                    .add(interiorPoint.getTags().get(POINT_STREET_NAME_KEY)));
 
         }
         // If there are Edges intersecting or contained by the bounding box
@@ -112,7 +114,7 @@ public class AddressPointMatchCheck extends BaseCheck
         {
             // Add all interior Edge street names to the list of candidate street names
             edges.forEach(interiorEdge -> streetNameList
-                    .add((interiorEdge.getTags().get(EDGE_STREET_NAME_KEY))));
+                    .add(interiorEdge.getTags().get(EDGE_STREET_NAME_KEY)));
         }
 
         return Optional.of(this.createFlag(point,

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/SelfIntersectingPolyLineCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/SelfIntersectingPolyLineCheckTest.java
@@ -1,6 +1,5 @@
 package org.openstreetmap.atlas.checks.validation.intersections;
 
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.openstreetmap.atlas.checks.configuration.ConfigurationResolver;
@@ -13,8 +12,9 @@ import org.openstreetmap.atlas.checks.validation.verifier.ConsumerBasedExpectedC
  */
 public class SelfIntersectingPolyLineCheckTest
 {
-    private static final SelfIntersectingPolylineCheck check = new SelfIntersectingPolylineCheck(
-            ConfigurationResolver.emptyConfiguration());
+    private final SelfIntersectingPolylineCheck check = new SelfIntersectingPolylineCheck(
+            ConfigurationResolver.inlineConfiguration(
+                    "{\"SelfIntersectingPolylineCheck\":{\"tags.filter\":\"highway->!proposed&highway->!construction&highway->!footway&highway->!path\"}}"));
 
     @Rule
     public SelfIntersectingPolylineTestCaseRule setup = new SelfIntersectingPolylineTestCaseRule();
@@ -23,17 +23,100 @@ public class SelfIntersectingPolyLineCheckTest
     public ConsumerBasedExpectedCheckVerifier verifier = new ConsumerBasedExpectedCheckVerifier();
 
     @Test
-    public void testCheck()
+    public void testValidLineNoSelfIntersection()
     {
-        this.verifier.actual(this.setup.getAtlas(), check);
-        this.verifier.verifyExpectedSize(6);
-        this.verifier.verify(flag ->
-        {
-            Assert.assertTrue(
-                    this.setup.getInvalidAtlasEntityIdentifiers().contains(flag.getIdentifier()));
-            Assert.assertFalse(
-                    this.setup.getValidAtlasEntityIdentifiers().contains(flag.getIdentifier()));
-        });
+        this.verifier.actual(this.setup.getValidLineNoSelfIntersection(), check);
+        this.verifier.verifyExpectedSize(0);
     }
 
+    @Test
+    public void testInvalidLineNonShapeSelfIntersection()
+    {
+        this.verifier.actual(this.setup.getInvalidLineNonShapeSelfIntersection(), check);
+        this.verifier.verifyExpectedSize(1);
+    }
+
+    @Test
+    public void testInvalidLineShapePointSelfIntersection()
+    {
+        this.verifier.actual(this.setup.getInvalidLineShapePointSelfIntersection(), check);
+        this.verifier.verifyExpectedSize(1);
+    }
+
+    @Test
+    public void testInvalidLineGeometryWaterwayTag()
+    {
+        this.verifier.actual(this.setup.getInvalidLineGeometryWaterwayTag(), check);
+        this.verifier.verifyExpectedSize(0);
+    }
+
+    @Test
+    public void testInvalidLineGeometryHighwayFootwayTag()
+    {
+        this.verifier.actual(this.setup.getInvalidLineGeometryHighwayFootwayTag(), check);
+        this.verifier.verifyExpectedSize(0);
+    }
+
+    @Test
+    public void testValidEdgeNoSelfIntersection()
+    {
+        this.verifier.actual(this.setup.getValidEdgeNoSelfIntersection(), check);
+        this.verifier.verifyExpectedSize(0);
+    }
+
+    @Test
+    public void testInvalidEdgeNonShapeIntersection()
+    {
+        this.verifier.actual(this.setup.getInvalidEdgeNonShapeIntersection(), check);
+        this.verifier.verifyExpectedSize(1);
+    }
+
+    @Test
+    public void testInvalidEdgeShapeIntersection()
+    {
+        this.verifier.actual(this.setup.getInvalidEdgeShapeIntersection(), check);
+        this.verifier.verifyExpectedSize(1);
+    }
+
+    @Test
+    public void testInvalidEdgeGeometryHighwayPrimaryTag()
+    {
+        this.verifier.actual(this.setup.getInvalidEdgeGeometryHighwayPrimaryTag(), check);
+        this.verifier.verifyExpectedSize(1);
+    }
+
+    @Test
+    public void testInvalidEdgeGeometryBuildingTag()
+    {
+        this.verifier.actual(this.setup.getInvalidEdgeGeometryBuildingTag(), check);
+        this.verifier.verifyExpectedSize(1);
+    }
+
+    @Test
+    public void testValidAreaNoSelfIntersection()
+    {
+        this.verifier.actual(this.setup.getValidAreaNoSelfIntersection(), check);
+        this.verifier.verifyExpectedSize(0);
+    }
+
+    @Test
+    public void testInvalidAreaNonShapeSelfIntersection()
+    {
+        this.verifier.actual(this.setup.getInvalidAreaNonShapeSelfIntersection(), check);
+        this.verifier.verifyExpectedSize(1);
+    }
+
+    @Test
+    public void testInvalidAreaShapeIntersection()
+    {
+        this.verifier.actual(this.setup.getInvalidAreaShapeIntersection(), check);
+        this.verifier.verifyExpectedSize(1);
+    }
+
+    @Test
+    public void testInvalidAreaBuildTag()
+    {
+        this.verifier.actual(this.setup.getInvalidAreaBuildingTag(), check);
+        this.verifier.verifyExpectedSize(1);
+    }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/SelfIntersectingPolylineTestCaseRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/SelfIntersectingPolylineTestCaseRule.java
@@ -1,8 +1,5 @@
 package org.openstreetmap.atlas.checks.validation.intersections;
 
-import java.util.HashSet;
-import java.util.Set;
-
 import org.openstreetmap.atlas.geography.atlas.Atlas;
 import org.openstreetmap.atlas.utilities.testing.CoreTestRule;
 import org.openstreetmap.atlas.utilities.testing.TestAtlas;
@@ -21,94 +18,222 @@ public class SelfIntersectingPolylineTestCaseRule extends CoreTestRule
 {
     public static final String VALID_EDGE_ID = "101740465";
     public static final String VALID_LINE_ID = "102740465";
+    public static final String VALID_LINE_ID_2 = "10283065";
+    public static final String VALID_LINE_ID_3 = "10284065";
     public static final String VALID_AREA_ID = "103740465";
     public static final String INVALID_EDGE_ID_1 = "104740465";
     public static final String INVALID_EDGE_ID_2 = "105540465";
+    public static final String INVALID_EDGE_ID_3 = "105640465";
+    public static final String INVALID_EDGE_ID_4 = "105740465";
     public static final String INVALID_LINE_ID_1 = "106740465";
     public static final String INVALID_LINE_ID_2 = "107740465";
     public static final String INVALID_AREA_ID_1 = "108740465";
     public static final String INVALID_AREA_ID_2 = "109740465";
+    public static final String INVALID_AREA_ID_3 = "109840465";
     private static final String ONE = "-0.8385242, -80.4892702";
     private static final String TWO = "-0.8385546, -80.4891487";
     private static final String THREE = "-0.8386005, -80.4892233";
     private static final String FOUR = "-0.8384783, -80.4891956";
     private static final String FIVE = "-0.83855, -80.48922";
-    @TestAtlas(
 
-            nodes = {
-
-                    @Node(id = "1", coordinates = @Loc(value = ONE)),
-                    @Node(id = "2", coordinates = @Loc(value = TWO)),
-                    @Node(id = "3", coordinates = @Loc(value = THREE)),
-                    @Node(id = "4", coordinates = @Loc(value = FOUR)),
-                    @Node(id = "5", coordinates = @Loc(value = FIVE)) },
-
-            lines = {
-                    // Valid Line with no self-intersections
+    // Valid Line with no self-intersections
+    @TestAtlas(nodes = { @Node(id = "1", coordinates = @Loc(value = ONE)),
+            @Node(id = "2", coordinates = @Loc(value = TWO)),
+            @Node(id = "3", coordinates = @Loc(value = THREE)) }, lines = {
                     @Line(id = VALID_LINE_ID, coordinates = { @Loc(value = ONE),
-                            @Loc(value = THREE), @Loc(value = TWO) }),
-                    // Invalid Line with a non-shape self-intersection
+                            @Loc(value = THREE), @Loc(value = TWO) }) })
+    private Atlas validLineNoSelfIntersection;
+
+    // Invalid Line with a non-shape self-intersection
+    @TestAtlas(nodes = { @Node(id = "1", coordinates = @Loc(value = ONE)),
+            @Node(id = "2", coordinates = @Loc(value = TWO)),
+            @Node(id = "3", coordinates = @Loc(value = THREE)) }, lines = {
                     @Line(id = INVALID_LINE_ID_1, coordinates = { @Loc(value = ONE),
-                            @Loc(value = TWO), @Loc(value = THREE), @Loc(value = FOUR) }),
-                    // Invalid Line with a shape-point self-intersection
+                            @Loc(value = TWO), @Loc(value = THREE), @Loc(value = FOUR) }) })
+    private Atlas invalidLineNonShapeSelfIntersection;
+
+    // Invalid Line with a shape-point self-intersection
+    @TestAtlas(nodes = { @Node(id = "1", coordinates = @Loc(value = ONE)),
+            @Node(id = "2", coordinates = @Loc(value = TWO)),
+            @Node(id = "3", coordinates = @Loc(value = THREE)) }, lines = {
                     @Line(id = INVALID_LINE_ID_2, coordinates = { @Loc(value = ONE),
                             @Loc(value = FIVE), @Loc(value = TWO), @Loc(value = THREE),
-                            @Loc(value = FIVE), @Loc(value = FOUR) }) },
+                            @Loc(value = FIVE), @Loc(value = FOUR) }) })
+    private Atlas invalidLineShapePointSelfIntersection;
 
-            edges = {
-                    // Valid Edge with no self-intersections
+    // Invalid Line geometry with Waterway tag
+    @TestAtlas(nodes = { @Node(id = "1", coordinates = @Loc(value = ONE)),
+            @Node(id = "2", coordinates = @Loc(value = TWO)),
+            @Node(id = "3", coordinates = @Loc(value = THREE)) }, lines = {
+                    @Line(id = VALID_LINE_ID_2, coordinates = { @Loc(value = ONE),
+                            @Loc(value = TWO), @Loc(value = THREE),
+                            @Loc(value = FOUR) }, tags = { "waterway=river" }) })
+    private Atlas invalidLineGeometryWaterwayTag;
+
+    // Invalid Line geometry with highway=footway tag
+    @TestAtlas(nodes = { @Node(id = "1", coordinates = @Loc(value = ONE)),
+            @Node(id = "2", coordinates = @Loc(value = TWO)),
+            @Node(id = "3", coordinates = @Loc(value = THREE)) }, lines = {
+                    @Line(id = VALID_LINE_ID_3, coordinates = { @Loc(value = ONE),
+                            @Loc(value = TWO), @Loc(value = THREE),
+                            @Loc(value = FOUR) }, tags = { "highway=footway" }) })
+    private Atlas invalidLineGeometryHighwayFootwayTag;
+
+    // Valid Edge with no self-intersections
+    @TestAtlas(nodes = { @Node(id = "1", coordinates = @Loc(value = ONE)),
+            @Node(id = "2", coordinates = @Loc(value = TWO)),
+            @Node(id = "3", coordinates = @Loc(value = THREE)) }, edges = {
                     @Edge(id = VALID_EDGE_ID, coordinates = { @Loc(value = ONE),
-                            @Loc(value = THREE), @Loc(value = TWO) }, tags = { "highway=trunk" }),
-                    // Invalid Edge with a non-shape self-intersection
+                            @Loc(value = THREE), @Loc(value = TWO) }, tags = { "highway=trunk" }) })
+    private Atlas validEdgeNoSelfIntersection;
+
+    // Invalid Edge with a non-shape self-intersection
+    @TestAtlas(nodes = { @Node(id = "1", coordinates = @Loc(value = ONE)),
+            @Node(id = "2", coordinates = @Loc(value = TWO)),
+            @Node(id = "3", coordinates = @Loc(value = THREE)),
+            @Node(id = "4", coordinates = @Loc(value = FOUR)) }, edges = {
                     @Edge(id = INVALID_EDGE_ID_1, coordinates = { @Loc(value = ONE),
                             @Loc(value = TWO), @Loc(value = THREE),
-                            @Loc(value = FOUR) }, tags = { "highway=trunk" }),
-                    // Invalid Edge with a shape-point self-intersection
+                            @Loc(value = FOUR) }, tags = { "highway=trunk" }) })
+    private Atlas invalidEdgeNonShapeIntersection;
+
+    // Invalid Edge with a shape-point self-intersection
+    @TestAtlas(nodes = { @Node(id = "1", coordinates = @Loc(value = ONE)),
+            @Node(id = "2", coordinates = @Loc(value = TWO)),
+            @Node(id = "3", coordinates = @Loc(value = THREE)),
+            @Node(id = "4", coordinates = @Loc(value = FOUR)),
+            @Node(id = "5", coordinates = @Loc(value = FIVE)) }, edges = {
                     @Edge(id = INVALID_EDGE_ID_2, coordinates = { @Loc(value = ONE),
                             @Loc(value = FIVE), @Loc(value = TWO), @Loc(value = THREE),
-                            @Loc(value = FIVE), @Loc(value = FOUR) }, tags = { "highway=trunk" }) },
+                            @Loc(value = FIVE), @Loc(value = FOUR) }, tags = { "highway=trunk" }) })
+    private Atlas invalidEdgeShapeIntersection;
 
-            areas = {
-                    // Valid Area with no self-intersections
+    // Invalid Edge geometry with highway=primary tag
+    @TestAtlas(nodes = { @Node(id = "1", coordinates = @Loc(value = ONE)),
+            @Node(id = "2", coordinates = @Loc(value = TWO)),
+            @Node(id = "3", coordinates = @Loc(value = THREE)),
+            @Node(id = "4", coordinates = @Loc(value = FOUR)),
+            @Node(id = "5", coordinates = @Loc(value = FIVE)) }, edges = {
+                    @Edge(id = INVALID_EDGE_ID_3, coordinates = { @Loc(value = ONE),
+                            @Loc(value = FIVE), @Loc(value = TWO), @Loc(value = THREE),
+                            @Loc(value = FIVE),
+                            @Loc(value = FOUR) }, tags = { "highway=primary" }) })
+    private Atlas invalidEdgeGeometryHighwayPrimaryTag;
+
+    // Invalid Edge geometry with Building tag
+    @TestAtlas(nodes = { @Node(id = "1", coordinates = @Loc(value = ONE)),
+            @Node(id = "2", coordinates = @Loc(value = TWO)),
+            @Node(id = "3", coordinates = @Loc(value = THREE)),
+            @Node(id = "4", coordinates = @Loc(value = FOUR)) }, edges = {
+                    @Edge(id = INVALID_EDGE_ID_4, coordinates = { @Loc(value = ONE),
+                            @Loc(value = TWO), @Loc(value = THREE),
+                            @Loc(value = FOUR) }, tags = { "building=yes" }) })
+    private Atlas invalidEdgeGeometryBuildingTag;
+
+    // Valid Area with no self-intersections
+    @TestAtlas(nodes = { @Node(id = "1", coordinates = @Loc(value = ONE)),
+            @Node(id = "2", coordinates = @Loc(value = TWO)),
+            @Node(id = "3", coordinates = @Loc(value = THREE)) }, areas = {
                     @Area(id = VALID_AREA_ID, coordinates = { @Loc(value = ONE),
                             @Loc(value = THREE), @Loc(value = TWO), @Loc(value = FOUR),
-                            @Loc(value = ONE) }, tags = { "leisure=park" }),
-                    // Invalid Area with a non shape-point self-intersection
+                            @Loc(value = ONE) }, tags = { "leisure=park" }) })
+    private Atlas validAreaNoSelfIntersection;
+
+    // Invalid Area with a non shape-point self-intersection
+    @TestAtlas(nodes = { @Node(id = "1", coordinates = @Loc(value = ONE)),
+            @Node(id = "2", coordinates = @Loc(value = TWO)),
+            @Node(id = "3", coordinates = @Loc(value = THREE)) }, areas = {
                     @Area(id = INVALID_AREA_ID_1, coordinates = { @Loc(value = ONE),
                             @Loc(value = TWO), @Loc(value = THREE), @Loc(value = FOUR),
-                            @Loc(value = ONE) }, tags = { "leisure=park" }),
-                    // Invalid Area with a shape point self-intersection
+                            @Loc(value = ONE) }, tags = { "leisure=park" }) })
+    private Atlas invalidAreaNonShapeSelfIntersection;
+
+    // Invalid Area with a shape point self-intersection
+    @TestAtlas(nodes = { @Node(id = "1", coordinates = @Loc(value = ONE)),
+            @Node(id = "2", coordinates = @Loc(value = TWO)),
+            @Node(id = "3", coordinates = @Loc(value = THREE)) }, areas = {
                     @Area(id = INVALID_AREA_ID_2, coordinates = { @Loc(value = ONE),
                             @Loc(value = FIVE), @Loc(value = TWO), @Loc(value = THREE),
                             @Loc(value = FIVE), @Loc(value = FOUR),
                             @Loc(value = ONE) }, tags = { "leisure=park" }) })
+    private Atlas invalidAreaShapeIntersection;
 
-    private Atlas atlas;
+    @TestAtlas(nodes = { @Node(id = "1", coordinates = @Loc(value = ONE)),
+            @Node(id = "2", coordinates = @Loc(value = TWO)),
+            @Node(id = "3", coordinates = @Loc(value = THREE)) }, areas = {
+                    @Area(id = INVALID_AREA_ID_3, coordinates = { @Loc(value = ONE),
+                            @Loc(value = TWO), @Loc(value = THREE), @Loc(value = FOUR),
+                            @Loc(value = THREE), @Loc(value = FOUR),
+                            @Loc(value = ONE) }, tags = { "building=yes" }) })
+    private Atlas invalidAreaBuildingTag;
 
-    public Atlas getAtlas()
+    public Atlas getValidLineNoSelfIntersection()
     {
-        return this.atlas;
+        return this.validLineNoSelfIntersection;
     }
 
-    public Set<String> getInvalidAtlasEntityIdentifiers()
+    public Atlas getInvalidLineNonShapeSelfIntersection()
     {
-        final Set<String> invalidIdentifiers = new HashSet<>();
-        invalidIdentifiers.add(INVALID_LINE_ID_1);
-        invalidIdentifiers.add(INVALID_LINE_ID_2);
-        invalidIdentifiers.add(INVALID_EDGE_ID_1);
-        invalidIdentifiers.add(INVALID_EDGE_ID_2);
-        invalidIdentifiers.add(INVALID_AREA_ID_1);
-        invalidIdentifiers.add(INVALID_AREA_ID_2);
-        return invalidIdentifiers;
+        return this.invalidLineNonShapeSelfIntersection;
     }
 
-    public Set<String> getValidAtlasEntityIdentifiers()
+    public Atlas getInvalidLineShapePointSelfIntersection()
     {
-        final Set<String> validIdentifiers = new HashSet<>();
-        validIdentifiers.add(VALID_EDGE_ID);
-        validIdentifiers.add(VALID_LINE_ID);
-        validIdentifiers.add(VALID_AREA_ID);
-        return validIdentifiers;
+        return this.invalidLineShapePointSelfIntersection;
     }
 
+    public Atlas getInvalidLineGeometryWaterwayTag()
+    {
+        return this.invalidLineGeometryWaterwayTag;
+    }
+
+    public Atlas getInvalidLineGeometryHighwayFootwayTag()
+    {
+        return this.invalidLineGeometryHighwayFootwayTag;
+    }
+
+    public Atlas getValidEdgeNoSelfIntersection()
+    {
+        return this.validEdgeNoSelfIntersection;
+    }
+
+    public Atlas getInvalidEdgeNonShapeIntersection()
+    {
+        return this.invalidEdgeNonShapeIntersection;
+    }
+
+    public Atlas getInvalidEdgeShapeIntersection()
+    {
+        return this.invalidEdgeShapeIntersection;
+    }
+
+    public Atlas getInvalidEdgeGeometryHighwayPrimaryTag()
+    {
+        return this.invalidEdgeGeometryHighwayPrimaryTag;
+    }
+
+    public Atlas getInvalidEdgeGeometryBuildingTag()
+    {
+        return this.invalidEdgeGeometryBuildingTag;
+    }
+
+    public Atlas getValidAreaNoSelfIntersection()
+    {
+        return this.validAreaNoSelfIntersection;
+    }
+
+    public Atlas getInvalidAreaNonShapeSelfIntersection()
+    {
+        return this.invalidAreaNonShapeSelfIntersection;
+    }
+
+    public Atlas getInvalidAreaShapeIntersection()
+    {
+        return this.invalidAreaShapeIntersection;
+    }
+
+    public Atlas getInvalidAreaBuildingTag()
+    {
+        return this.invalidAreaBuildingTag;
+    }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SignPostCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SignPostCheckTest.java
@@ -8,7 +8,9 @@ import org.junit.Test;
 import org.openstreetmap.atlas.checks.configuration.ConfigurationResolver;
 import org.openstreetmap.atlas.checks.flag.CheckFlag;
 import org.openstreetmap.atlas.checks.flag.FlaggedObject;
+import org.openstreetmap.atlas.checks.flag.FlaggedPoint;
 import org.openstreetmap.atlas.checks.validation.verifier.ConsumerBasedExpectedCheckVerifier;
+import org.openstreetmap.atlas.geography.Location;
 
 /**
  * Tests for {@link SignPostCheck}
@@ -18,7 +20,11 @@ import org.openstreetmap.atlas.checks.validation.verifier.ConsumerBasedExpectedC
 public class SignPostCheckTest
 {
     private static SignPostCheck CHECK = new SignPostCheck(
-            ConfigurationResolver.emptyConfiguration());
+            ConfigurationResolver.inlineConfiguration(
+                    "{" + "\"SignPostCheck.source.filter\": \"highway->motorway,trunk,primary|motorroad->yes\", "
+                            + "\"SignPostCheck.ramp.filter\": \"highway->motorway_link,trunk_link,primary,primary_link&motorroad->!\","
+                            + "\"SignPostCheck.ramp.differentiator.tag\": \"diff\","
+                            + "\"SignPostCheck.ramp.angle.difference.degrees\": 90.0" + "}"));
 
     @Rule
     public SignPostCheckTestRule setup = new SignPostCheckTestRule();
@@ -26,15 +32,12 @@ public class SignPostCheckTest
     @Rule
     public ConsumerBasedExpectedCheckVerifier verifier = new ConsumerBasedExpectedCheckVerifier();
 
-    private static void verify(final CheckFlag flag, final boolean shouldFlagDestination,
-            final boolean shouldFlagJunction)
+    private static void verify(final CheckFlag flag, final int expectedFlaggedObjectCount,
+            final boolean shouldFlagDestination, final boolean shouldFlagJunction)
     {
-        // Verify that only node is flagged
+        // Verify that node and edge is flagged
         final Set<FlaggedObject> flaggedObjects = flag.getFlaggedObjects();
-        Assert.assertEquals(1, flaggedObjects.size());
-
-        // Verify the node id
-        Assert.assertEquals(SignPostCheckTestRule.JUNCTION_NODE_ID, flag.getIdentifier());
+        Assert.assertEquals(expectedFlaggedObjectCount, flaggedObjects.size());
 
         // Verify the instruction tag keys and values
         Assert.assertTrue(!shouldFlagDestination || flag.getInstructions().contains("destination"));
@@ -43,12 +46,48 @@ public class SignPostCheckTest
     }
 
     @Test
+    public void motorroadPrimaryLinkMissingJunctionAndDestinationAtlas()
+    {
+        this.verifier.actual(this.setup.motorroadPrimaryLinkMissingJunctionAndDestinationAtlas(),
+                CHECK);
+        this.verifier.verifyExpectedSize(1);
+        this.verifier.verify(flag -> verify(flag, 2, true, true));
+    }
+
+    @Test
+    public void motorroadPrimaryMissingJunctionAndDestinationAtlas()
+    {
+        this.verifier.actual(this.setup.motorroadPrimaryMissingJunctionAndDestinationAtlas(),
+                CHECK);
+        this.verifier.verifyExpectedSize(1);
+        this.verifier.verify(flag -> verify(flag, 2, true, true));
+    }
+
+    @Test
+    public void motorwayLinkMotorwayMissingJunctionAndDestinationAtlas()
+    {
+        this.verifier.actual(this.setup.motorwayLinkMotorwayMissingJunctionAndDestinationAtlas(),
+                CHECK);
+        this.verifier.verifyExpectedSize(1);
+        this.verifier.verify(flag -> verify(flag, 2, true, true));
+
+        // Verify that we flagged starting node of the ramp (formed by single edge)
+        this.verifier.verify(flag ->
+        {
+            final FlaggedObject flaggedPoint = flag.getFlaggedObjects().stream()
+                    .filter(object -> object instanceof FlaggedPoint).findFirst().get();
+            final Location flaggedLocation = flaggedPoint.getGeometry().iterator().next();
+            Assert.assertEquals(Location.forString(SignPostCheckTestRule.LINK_1), flaggedLocation);
+        });
+    }
+
+    @Test
     public void motorwayMotorwayLinkMissingJunctionAndDestinationAtlas()
     {
         this.verifier.actual(this.setup.motorwayMotorwayLinkMissingJunctionAndDestinationAtlas(),
                 CHECK);
         this.verifier.verifyExpectedSize(1);
-        this.verifier.verify(flag -> verify(flag, true, true));
+        this.verifier.verify(flag -> verify(flag, 2, true, true));
     }
 
     @Test
@@ -65,7 +104,7 @@ public class SignPostCheckTest
         this.verifier.actual(this.setup.motorwayMultipleLinksMissingJunctionAndDestinationAtlas(),
                 CHECK);
         this.verifier.verifyExpectedSize(1);
-        this.verifier.verify(flag -> verify(flag, true, true));
+        this.verifier.verify(flag -> verify(flag, 3, true, true));
     }
 
     @Test
@@ -73,7 +112,8 @@ public class SignPostCheckTest
     {
         this.verifier.actual(this.setup.motorwayPrimaryLinkMissingJunctionAndDestinationAtlas(),
                 CHECK);
-        this.verifier.verifyEmpty();
+        this.verifier.verifyExpectedSize(1);
+        this.verifier.verify(flag -> verify(flag, 2, true, true));
     }
 
     @Test
@@ -98,7 +138,7 @@ public class SignPostCheckTest
         this.verifier.actual(this.setup.motorwayTrunkLinkMissingJunctionAndDestinationAtlas(),
                 CHECK);
         this.verifier.verifyExpectedSize(1);
-        this.verifier.verify(flag -> verify(flag, true, true));
+        this.verifier.verify(flag -> verify(flag, 2, true, true));
     }
 
     @Test
@@ -106,25 +146,25 @@ public class SignPostCheckTest
     {
         this.verifier.actual(this.setup.motorwayTrunkLinkWithDestinationAtlas(), CHECK);
         this.verifier.verifyExpectedSize(1);
-        this.verifier.verify(flag -> verify(flag, false, true));
+        this.verifier.verify(flag -> verify(flag, 1, false, true));
     }
 
     @Test
-    public void primaryLinkMotorwayLinkMissingJunctionAndDestinationAtlas()
+    public void primaryLinkTrunkMissingJunctionAndDestinationAtlas()
     {
-        this.verifier.actual(this.setup.primaryLinkMotorwayLinkMissingJunctionAndDestinationAtlas(),
+        this.verifier.actual(this.setup.primaryLinkTrunkMissingJunctionAndDestinationAtlas(),
                 CHECK);
         this.verifier.verifyExpectedSize(1);
-        this.verifier.verify(flag -> verify(flag, true, true));
-    }
+        this.verifier.verify(flag -> verify(flag, 2, true, true));
 
-    @Test
-    public void primaryLinkTrunkLinkMissingJunctionAndDestinationAtlas()
-    {
-        this.verifier.actual(this.setup.primaryLinkTrunkLinkMissingJunctionAndDestinationAtlas(),
-                CHECK);
-        this.verifier.verifyExpectedSize(1);
-        this.verifier.verify(flag -> verify(flag, true, true));
+        // Verify that we flagged starting node of the ramp (formed by 2 edges)
+        this.verifier.verify(flag ->
+        {
+            final FlaggedObject flaggedPoint = flag.getFlaggedObjects().stream()
+                    .filter(object -> object instanceof FlaggedPoint).findFirst().get();
+            final Location flaggedLocation = flaggedPoint.getGeometry().iterator().next();
+            Assert.assertEquals(Location.forString(SignPostCheckTestRule.LINK_1), flaggedLocation);
+        });
     }
 
     @Test
@@ -133,7 +173,7 @@ public class SignPostCheckTest
         this.verifier.actual(this.setup.primaryMotorwayLinkMissingJunctionAndDestinationAtlas(),
                 CHECK);
         this.verifier.verifyExpectedSize(1);
-        this.verifier.verify(flag -> verify(flag, true, true));
+        this.verifier.verify(flag -> verify(flag, 2, true, true));
     }
 
     @Test
@@ -142,7 +182,7 @@ public class SignPostCheckTest
         this.verifier.actual(this.setup.primaryTrunkLinkMissingJunctionAndDestinationAtlas(),
                 CHECK);
         this.verifier.verifyExpectedSize(1);
-        this.verifier.verify(flag -> verify(flag, true, true));
+        this.verifier.verify(flag -> verify(flag, 2, true, true));
     }
 
     @Test
@@ -151,7 +191,7 @@ public class SignPostCheckTest
         this.verifier.actual(this.setup.trunkMotorwayLinkMissingJunctionAndDestinationAtlas(),
                 CHECK);
         this.verifier.verifyExpectedSize(1);
-        this.verifier.verify(flag -> verify(flag, true, true));
+        this.verifier.verify(flag -> verify(flag, 2, true, true));
     }
 
     @Test
@@ -159,15 +199,7 @@ public class SignPostCheckTest
     {
         this.verifier.actual(this.setup.trunkMotorwayLinkWithJunctionAtlas(), CHECK);
         this.verifier.verifyExpectedSize(1);
-        this.verifier.verify(flag -> verify(flag, true, false));
-    }
-
-    @Test
-    public void trunkPrimaryLinkMissingJunctionAndDestinationAtlas()
-    {
-        this.verifier.actual(this.setup.trunkPrimaryLinkMissingJunctionAndDestinationAtlas(),
-                CHECK);
-        this.verifier.verifyEmpty();
+        this.verifier.verify(flag -> verify(flag, 1, true, false));
     }
 
     @Test
@@ -191,6 +223,14 @@ public class SignPostCheckTest
     {
         this.verifier.actual(this.setup.trunkTrunkLinkMissingJunctionAndDestinationAtlas(), CHECK);
         this.verifier.verifyExpectedSize(1);
-        this.verifier.verify(flag -> verify(flag, true, true));
+        this.verifier.verify(flag -> verify(flag, 2, true, true));
+    }
+
+    @Test
+    public void unclassifiedPrimaryLinkMissingJunctionAndDestinationAtlas()
+    {
+        this.verifier.actual(this.setup.unclassifiedPrimaryLinkMissingJunctionAndDestinationAtlas(),
+                CHECK);
+        this.verifier.verifyEmpty();
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SignPostCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SignPostCheckTestRule.java
@@ -20,18 +20,21 @@ public class SignPostCheckTestRule extends CoreTestRule
     private static final String HIGHWAY_4 = "47.641319, -122.322601";
     private static final String HIGHWAY_5 = "47.643585, -122.322487";
 
-    private static final String LINK_1 = "47.639336, -122.322525";
+    private static final String HIGHWAY2_1 = "47.642048, -122.324181";
+    private static final String HIGHWAY2_2 = "47.642769, -122.317772";
+    private static final String HIGHWAY2_3 = "47.643078, -122.314384";
+
+    static final String LINK_1 = "47.639336, -122.322525";
     private static final String LINK_2 = "47.640697, -122.322395";
     private static final String LINK_3 = "47.642033, -122.321556";
     private static final String LINK_4 = "47.642471, -122.319885";
-    private static final String LINK_5 = "47.641216, -122.3218";
 
-    public static final String JUNCTION_NODE_ID = "123456789";
+    private static final String LINK2_1 = "47.641216, -122.3218";
 
     @TestAtlas(
             // nodes
             nodes = { @Node(coordinates = @Loc(value = HIGHWAY_1)),
-                    @Node(id = JUNCTION_NODE_ID, coordinates = @Loc(value = HIGHWAY_3)),
+                    @Node(coordinates = @Loc(value = HIGHWAY_3)),
                     @Node(coordinates = @Loc(value = HIGHWAY_5)),
                     @Node(coordinates = @Loc(value = LINK_1)) },
             // edges
@@ -47,7 +50,7 @@ public class SignPostCheckTestRule extends CoreTestRule
     @TestAtlas(
             // nodes
             nodes = { @Node(coordinates = @Loc(value = HIGHWAY_1)),
-                    @Node(id = JUNCTION_NODE_ID, coordinates = @Loc(value = HIGHWAY_3)),
+                    @Node(coordinates = @Loc(value = HIGHWAY_3)),
                     @Node(coordinates = @Loc(value = HIGHWAY_5)),
                     @Node(coordinates = @Loc(value = LINK_1)) },
             // edges
@@ -63,7 +66,7 @@ public class SignPostCheckTestRule extends CoreTestRule
     @TestAtlas(
             // nodes
             nodes = { @Node(coordinates = @Loc(value = HIGHWAY_1)),
-                    @Node(id = JUNCTION_NODE_ID, coordinates = @Loc(value = HIGHWAY_3)),
+                    @Node(coordinates = @Loc(value = HIGHWAY_3)),
                     @Node(coordinates = @Loc(value = HIGHWAY_5)),
                     @Node(coordinates = @Loc(value = LINK_1)) },
             // edges
@@ -79,7 +82,7 @@ public class SignPostCheckTestRule extends CoreTestRule
     @TestAtlas(
             // nodes
             nodes = { @Node(coordinates = @Loc(value = HIGHWAY_1)),
-                    @Node(id = JUNCTION_NODE_ID, coordinates = @Loc(value = HIGHWAY_3)),
+                    @Node(coordinates = @Loc(value = HIGHWAY_3)),
                     @Node(coordinates = @Loc(value = HIGHWAY_5)),
                     @Node(coordinates = @Loc(value = LINK_1)) },
             // edges
@@ -95,7 +98,7 @@ public class SignPostCheckTestRule extends CoreTestRule
     @TestAtlas(
             // nodes
             nodes = { @Node(coordinates = @Loc(value = HIGHWAY_1)),
-                    @Node(id = JUNCTION_NODE_ID, coordinates = @Loc(value = HIGHWAY_3)),
+                    @Node(coordinates = @Loc(value = HIGHWAY_3)),
                     @Node(coordinates = @Loc(value = HIGHWAY_5)),
                     @Node(coordinates = @Loc(value = LINK_1)),
                     @Node(coordinates = @Loc(value = LINK_4)) },
@@ -113,7 +116,26 @@ public class SignPostCheckTestRule extends CoreTestRule
     @TestAtlas(
             // nodes
             nodes = { @Node(coordinates = @Loc(value = HIGHWAY_1)),
-                    @Node(id = JUNCTION_NODE_ID, coordinates = @Loc(value = HIGHWAY_3)),
+                    @Node(coordinates = @Loc(value = HIGHWAY_3)),
+                    @Node(coordinates = @Loc(value = HIGHWAY_5)),
+                    @Node(coordinates = @Loc(value = LINK_1)),
+                    @Node(coordinates = @Loc(value = LINK_4)) },
+            // edges
+            edges = { @Edge(coordinates = { @Loc(value = HIGHWAY_1), @Loc(value = HIGHWAY_2),
+                    @Loc(value = HIGHWAY_3) }, tags = { "highway=primary", "motorroad=yes" }),
+                    @Edge(coordinates = { @Loc(value = HIGHWAY_3), @Loc(value = HIGHWAY_4),
+                            @Loc(value = HIGHWAY_5) }, tags = { "highway=primary",
+                                    "motorroad=yes" }),
+                    @Edge(coordinates = { @Loc(value = HIGHWAY_3), @Loc(value = LINK_1),
+                            @Loc(value = LINK_2), @Loc(value = LINK_3),
+                            @Loc(value = LINK_4) }, tags = { "highway=primary",
+                                    "diff=treat-me-different" }) })
+    private Atlas motorroadPrimaryMissingJunctionAndDestinationAtlas;
+
+    @TestAtlas(
+            // nodes
+            nodes = { @Node(coordinates = @Loc(value = HIGHWAY_1)),
+                    @Node(coordinates = @Loc(value = HIGHWAY_3)),
                     @Node(coordinates = @Loc(value = HIGHWAY_5)),
                     @Node(coordinates = @Loc(value = LINK_1)),
                     @Node(coordinates = @Loc(value = LINK_4)) },
@@ -131,7 +153,7 @@ public class SignPostCheckTestRule extends CoreTestRule
     @TestAtlas(
             // nodes
             nodes = { @Node(coordinates = @Loc(value = HIGHWAY_1)),
-                    @Node(id = JUNCTION_NODE_ID, coordinates = @Loc(value = HIGHWAY_3)),
+                    @Node(coordinates = @Loc(value = HIGHWAY_3)),
                     @Node(coordinates = @Loc(value = HIGHWAY_5)),
                     @Node(coordinates = @Loc(value = LINK_1)),
                     @Node(coordinates = @Loc(value = LINK_4)) },
@@ -149,7 +171,7 @@ public class SignPostCheckTestRule extends CoreTestRule
     @TestAtlas(
             // nodes
             nodes = { @Node(coordinates = @Loc(value = HIGHWAY_1)),
-                    @Node(id = JUNCTION_NODE_ID, coordinates = @Loc(value = HIGHWAY_3)),
+                    @Node(coordinates = @Loc(value = HIGHWAY_3)),
                     @Node(coordinates = @Loc(value = HIGHWAY_5)),
                     @Node(coordinates = @Loc(value = LINK_1)),
                     @Node(coordinates = @Loc(value = LINK_4)) },
@@ -167,11 +189,11 @@ public class SignPostCheckTestRule extends CoreTestRule
     @TestAtlas(
             // nodes
             nodes = { @Node(coordinates = @Loc(value = HIGHWAY_1)),
-                    @Node(id = JUNCTION_NODE_ID, coordinates = @Loc(value = HIGHWAY_3)),
+                    @Node(coordinates = @Loc(value = HIGHWAY_3)),
                     @Node(coordinates = @Loc(value = HIGHWAY_5)),
                     @Node(coordinates = @Loc(value = LINK_1)),
                     @Node(coordinates = @Loc(value = LINK_4)),
-                    @Node(coordinates = @Loc(value = LINK_5)) },
+                    @Node(coordinates = @Loc(value = LINK2_1)) },
             // edges
             edges = {
                     @Edge(coordinates = { @Loc(value = HIGHWAY_1), @Loc(value = HIGHWAY_2),
@@ -183,31 +205,49 @@ public class SignPostCheckTestRule extends CoreTestRule
                             @Loc(value = LINK_4) }, tags = { "highway=motorway_link" }),
                     @Edge(coordinates = { @Loc(value = HIGHWAY_3), @Loc(value = LINK_1),
                             @Loc(value = LINK_2),
-                            @Loc(value = LINK_5) }, tags = { "highway=trunk_link" }) })
+                            @Loc(value = LINK2_1) }, tags = { "highway=trunk_link" }) })
     private Atlas motorwayMultipleLinksMissingJunctionAndDestinationAtlas;
 
     @TestAtlas(
             // nodes
             nodes = { @Node(coordinates = @Loc(value = HIGHWAY_1)),
-                    @Node(id = JUNCTION_NODE_ID, coordinates = @Loc(value = HIGHWAY_3)),
+                    @Node(coordinates = @Loc(value = HIGHWAY_3)),
+                    @Node(coordinates = @Loc(value = HIGHWAY_5)),
+                    @Node(coordinates = @Loc(value = LINK_1)),
+                    @Node(coordinates = @Loc(value = LINK_4)) },
+            // edges
+            edges = { @Edge(coordinates = { @Loc(value = HIGHWAY_1), @Loc(value = HIGHWAY_2),
+                    @Loc(value = HIGHWAY_3) }, tags = { "highway=primary", "motorroad=yes" }),
+                    @Edge(coordinates = { @Loc(value = HIGHWAY_3), @Loc(value = HIGHWAY_4),
+                            @Loc(value = HIGHWAY_5) }, tags = { "highway=primary",
+                                    "motorroad=yes" }),
+                    @Edge(coordinates = { @Loc(value = HIGHWAY_3), @Loc(value = LINK_1),
+                            @Loc(value = LINK_2), @Loc(value = LINK_3),
+                            @Loc(value = LINK_4) }, tags = { "highway=primary_link" }) })
+    private Atlas motorroadPrimaryLinkMissingJunctionAndDestinationAtlas;
+
+    @TestAtlas(
+            // nodes
+            nodes = { @Node(coordinates = @Loc(value = HIGHWAY_1)),
+                    @Node(coordinates = @Loc(value = HIGHWAY_3)),
                     @Node(coordinates = @Loc(value = HIGHWAY_5)),
                     @Node(coordinates = @Loc(value = LINK_1)),
                     @Node(coordinates = @Loc(value = LINK_4)) },
             // edges
             edges = {
                     @Edge(coordinates = { @Loc(value = HIGHWAY_1), @Loc(value = HIGHWAY_2),
-                            @Loc(value = HIGHWAY_3) }, tags = { "highway=trunk" }),
+                            @Loc(value = HIGHWAY_3) }, tags = { "highway=unclassified" }),
                     @Edge(coordinates = { @Loc(value = HIGHWAY_3), @Loc(value = HIGHWAY_4),
-                            @Loc(value = HIGHWAY_5) }, tags = { "highway=trunk" }),
+                            @Loc(value = HIGHWAY_5) }, tags = { "highway=unclassified" }),
                     @Edge(coordinates = { @Loc(value = HIGHWAY_3), @Loc(value = LINK_1),
                             @Loc(value = LINK_2), @Loc(value = LINK_3),
                             @Loc(value = LINK_4) }, tags = { "highway=primary_link" }) })
-    private Atlas trunkPrimaryLinkMissingJunctionAndDestinationAtlas;
+    private Atlas unclassifiedPrimaryLinkMissingJunctionAndDestinationAtlas;
 
     @TestAtlas(
             // nodes
             nodes = { @Node(coordinates = @Loc(value = HIGHWAY_1)),
-                    @Node(id = JUNCTION_NODE_ID, coordinates = @Loc(value = HIGHWAY_3)),
+                    @Node(coordinates = @Loc(value = HIGHWAY_3)),
                     @Node(coordinates = @Loc(value = HIGHWAY_5)),
                     @Node(coordinates = @Loc(value = LINK_1)),
                     @Node(coordinates = @Loc(value = LINK_4)) },
@@ -225,7 +265,7 @@ public class SignPostCheckTestRule extends CoreTestRule
     @TestAtlas(
             // nodes
             nodes = { @Node(coordinates = @Loc(value = HIGHWAY_1)),
-                    @Node(id = JUNCTION_NODE_ID, coordinates = @Loc(value = HIGHWAY_3)),
+                    @Node(coordinates = @Loc(value = HIGHWAY_3)),
                     @Node(coordinates = @Loc(value = HIGHWAY_5)),
                     @Node(coordinates = @Loc(value = LINK_1)),
                     @Node(coordinates = @Loc(value = LINK_4)) },
@@ -243,25 +283,28 @@ public class SignPostCheckTestRule extends CoreTestRule
     @TestAtlas(
             // nodes
             nodes = { @Node(coordinates = @Loc(value = HIGHWAY_1)),
-                    @Node(id = JUNCTION_NODE_ID, coordinates = @Loc(value = HIGHWAY_3)),
-                    @Node(coordinates = @Loc(value = HIGHWAY_5)),
+                    @Node(coordinates = @Loc(value = HIGHWAY2_1)),
+                    @Node(coordinates = @Loc(value = HIGHWAY2_3)),
                     @Node(coordinates = @Loc(value = LINK_1)),
+                    @Node(coordinates = @Loc(value = LINK_3)),
                     @Node(coordinates = @Loc(value = LINK_4)) },
             // edges
             edges = {
+                    @Edge(coordinates = { @Loc(value = LINK_1), @Loc(value = LINK_2),
+                            @Loc(value = LINK_3) }, tags = { "highway=primary_link" }),
+                    @Edge(coordinates = { @Loc(value = LINK_3), @Loc(value = LINK_4) }, tags = {
+                            "highway=primary_link" }),
                     @Edge(coordinates = { @Loc(value = HIGHWAY_1), @Loc(value = HIGHWAY_2),
-                            @Loc(value = HIGHWAY_3) }, tags = { "highway=primary_link" }),
-                    @Edge(coordinates = { @Loc(value = HIGHWAY_3), @Loc(value = HIGHWAY_4),
-                            @Loc(value = HIGHWAY_5) }, tags = { "highway=primary_link" }),
-                    @Edge(coordinates = { @Loc(value = HIGHWAY_3), @Loc(value = LINK_1),
-                            @Loc(value = LINK_2), @Loc(value = LINK_3),
-                            @Loc(value = LINK_4) }, tags = { "highway=trunk_link" }) })
-    private Atlas primaryLinkTrunkLinkMissingJunctionAndDestinationAtlas;
+                            @Loc(value = HIGHWAY2_1),
+                            @Loc(value = LINK_4) }, tags = { "highway=motorway" }),
+                    @Edge(coordinates = { @Loc(value = LINK_4), @Loc(value = HIGHWAY2_2),
+                            @Loc(value = HIGHWAY2_3) }, tags = { "highway=motorway" }) })
+    private Atlas primaryLinkTrunkMissingJunctionAndDestinationAtlas;
 
     @TestAtlas(
             // nodes
             nodes = { @Node(coordinates = @Loc(value = HIGHWAY_1)),
-                    @Node(id = JUNCTION_NODE_ID, coordinates = @Loc(value = HIGHWAY_3)),
+                    @Node(coordinates = @Loc(value = HIGHWAY_3)),
                     @Node(coordinates = @Loc(value = HIGHWAY_5)),
                     @Node(coordinates = @Loc(value = LINK_1)),
                     @Node(coordinates = @Loc(value = LINK_4)) },
@@ -279,25 +322,26 @@ public class SignPostCheckTestRule extends CoreTestRule
     @TestAtlas(
             // nodes
             nodes = { @Node(coordinates = @Loc(value = HIGHWAY_1)),
-                    @Node(id = JUNCTION_NODE_ID, coordinates = @Loc(value = HIGHWAY_3)),
-                    @Node(coordinates = @Loc(value = HIGHWAY_5)),
+                    @Node(coordinates = @Loc(value = HIGHWAY2_1)),
+                    @Node(coordinates = @Loc(value = HIGHWAY2_3)),
                     @Node(coordinates = @Loc(value = LINK_1)),
                     @Node(coordinates = @Loc(value = LINK_4)) },
             // edges
             edges = {
+                    @Edge(coordinates = { @Loc(value = LINK_1), @Loc(value = LINK_2),
+                            @Loc(value = LINK_3),
+                            @Loc(value = LINK_4) }, tags = { "highway=motorway_link" }),
                     @Edge(coordinates = { @Loc(value = HIGHWAY_1), @Loc(value = HIGHWAY_2),
-                            @Loc(value = HIGHWAY_3) }, tags = { "highway=primary_link" }),
-                    @Edge(coordinates = { @Loc(value = HIGHWAY_3), @Loc(value = HIGHWAY_4),
-                            @Loc(value = HIGHWAY_5) }, tags = { "highway=primary_link" }),
-                    @Edge(coordinates = { @Loc(value = HIGHWAY_3), @Loc(value = LINK_1),
-                            @Loc(value = LINK_2), @Loc(value = LINK_3),
-                            @Loc(value = LINK_4) }, tags = { "highway=motorway_link" }) })
-    private Atlas primaryLinkMotorwayLinkMissingJunctionAndDestinationAtlas;
+                            @Loc(value = HIGHWAY2_1),
+                            @Loc(value = LINK_4) }, tags = { "highway=motorway" }),
+                    @Edge(coordinates = { @Loc(value = LINK_4), @Loc(value = HIGHWAY2_2),
+                            @Loc(value = HIGHWAY2_3) }, tags = { "highway=motorway" }) })
+    private Atlas motorwayLinkMotorwayMissingJunctionAndDestinationAtlas;
 
     @TestAtlas(
             // nodes
             nodes = { @Node(coordinates = @Loc(value = HIGHWAY_1)),
-                    @Node(id = JUNCTION_NODE_ID, coordinates = @Loc(value = HIGHWAY_3)),
+                    @Node(coordinates = @Loc(value = HIGHWAY_3)),
                     @Node(coordinates = @Loc(value = HIGHWAY_5)),
                     @Node(coordinates = @Loc(value = LINK_1)),
                     @Node(coordinates = @Loc(value = LINK_4)) },
@@ -316,7 +360,7 @@ public class SignPostCheckTestRule extends CoreTestRule
     @TestAtlas(
             // nodes
             nodes = { @Node(coordinates = @Loc(value = HIGHWAY_1)),
-                    @Node(id = JUNCTION_NODE_ID, coordinates = @Loc(value = HIGHWAY_3), tags = {
+                    @Node(coordinates = @Loc(value = HIGHWAY_3), tags = {
                             "highway=motorway_junction" }),
                     @Node(coordinates = @Loc(value = HIGHWAY_5)),
                     @Node(coordinates = @Loc(value = LINK_1)),
@@ -335,7 +379,7 @@ public class SignPostCheckTestRule extends CoreTestRule
     @TestAtlas(
             // nodes
             nodes = { @Node(coordinates = @Loc(value = HIGHWAY_1)),
-                    @Node(id = JUNCTION_NODE_ID, coordinates = @Loc(value = HIGHWAY_3), tags = {
+                    @Node(coordinates = @Loc(value = HIGHWAY_3), tags = {
                             "highway=motorway_junction" }),
                     @Node(coordinates = @Loc(value = HIGHWAY_5)),
                     @Node(coordinates = @Loc(value = LINK_1)),
@@ -351,6 +395,21 @@ public class SignPostCheckTestRule extends CoreTestRule
                             @Loc(value = LINK_4) }, tags = { "highway=motorway_link",
                                     "destination=somewhere" }) })
     private Atlas motorwayMotorwayLinkWithJunctionAndDestinationAtlas;
+
+    public Atlas motorroadPrimaryLinkMissingJunctionAndDestinationAtlas()
+    {
+        return this.motorroadPrimaryLinkMissingJunctionAndDestinationAtlas;
+    }
+
+    public Atlas motorroadPrimaryMissingJunctionAndDestinationAtlas()
+    {
+        return this.motorroadPrimaryMissingJunctionAndDestinationAtlas;
+    }
+
+    public Atlas motorwayLinkMotorwayMissingJunctionAndDestinationAtlas()
+    {
+        return this.motorwayLinkMotorwayMissingJunctionAndDestinationAtlas;
+    }
 
     public Atlas motorwayMotorwayLinkMissingJunctionAndDestinationAtlas()
     {
@@ -392,14 +451,9 @@ public class SignPostCheckTestRule extends CoreTestRule
         return this.motorwayTrunkLinkWithDestinationAtlas;
     }
 
-    public Atlas primaryLinkMotorwayLinkMissingJunctionAndDestinationAtlas()
+    public Atlas primaryLinkTrunkMissingJunctionAndDestinationAtlas()
     {
-        return this.primaryLinkMotorwayLinkMissingJunctionAndDestinationAtlas;
-    }
-
-    public Atlas primaryLinkTrunkLinkMissingJunctionAndDestinationAtlas()
-    {
-        return this.primaryLinkTrunkLinkMissingJunctionAndDestinationAtlas;
+        return this.primaryLinkTrunkMissingJunctionAndDestinationAtlas;
     }
 
     public Atlas primaryMotorwayLinkMissingJunctionAndDestinationAtlas()
@@ -422,11 +476,6 @@ public class SignPostCheckTestRule extends CoreTestRule
         return this.trunkMotorwayLinkWithJunctionAtlas;
     }
 
-    public Atlas trunkPrimaryLinkMissingJunctionAndDestinationAtlas()
-    {
-        return this.trunkPrimaryLinkMissingJunctionAndDestinationAtlas;
-    }
-
     public Atlas trunkShortMotorwayLinkMissingJunctionAndDestinationAtlas()
     {
         return this.trunkShortMotorwayLinkMissingJunctionAndDestinationAtlas;
@@ -440,5 +489,10 @@ public class SignPostCheckTestRule extends CoreTestRule
     public Atlas trunkTrunkLinkMissingJunctionAndDestinationAtlas()
     {
         return this.trunkTrunkLinkMissingJunctionAndDestinationAtlas;
+    }
+
+    public Atlas unclassifiedPrimaryLinkMissingJunctionAndDestinationAtlas()
+    {
+        return this.unclassifiedPrimaryLinkMissingJunctionAndDestinationAtlas;
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/points/AddressPointMatchCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/points/AddressPointMatchCheckTest.java
@@ -1,7 +1,11 @@
 package org.openstreetmap.atlas.checks.validation.points;
 
+import org.junit.Assert;
 import org.junit.Rule;
+import org.junit.Test;
+import org.openstreetmap.atlas.checks.configuration.ConfigurationResolver;
 import org.openstreetmap.atlas.checks.validation.verifier.ConsumerBasedExpectedCheckVerifier;
+import org.openstreetmap.atlas.utilities.configuration.Configuration;
 
 /**
  * Tests for {@link AddressPointMatchCheck}
@@ -10,10 +14,68 @@ import org.openstreetmap.atlas.checks.validation.verifier.ConsumerBasedExpectedC
  */
 public class AddressPointMatchCheckTest
 {
+    private final AddressPointMatchCheck check = new AddressPointMatchCheck(
+            ConfigurationResolver.inlineConfiguration(
+                    "{\"AddressPointMatchCheck\":{\"bounds.size\":100.0"));
     @Rule
     public AddressPointMatchCheckTestRule setup = new AddressPointMatchCheckTestRule();
 
     @Rule
     public ConsumerBasedExpectedCheckVerifier verifier = new ConsumerBasedExpectedCheckVerifier();
+
+    @Test
+    public void pointWithStreetNameStreetNumber()
+    {
+        this.verifier.actual(this.setup.pointWithStreetNameStreetNumber(),
+                new AddressPointMatchCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+
+    @Test
+    public void pointWithStreetNameNoStreetNumberNoCandidates()
+    {
+        this.verifier.actual(this.setup.pointWithStreetNameNoStreetNumberNoCandidates(),
+                new AddressPointMatchCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+    }
+
+    @Test
+    public void pointWithStreetNameNoStreetNumberPointCandidatesNoDuplicates()
+    {
+        this.verifier.actual(this.setup.pointWithStreetNameNoStreetNumberPointCandidatesNoDuplicates(),
+                new AddressPointMatchCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+    }
+
+    @Test
+    public void pointWithStreetNameNoStreetNumberEdgeCandidatesNoDuplicates()
+    {
+        this.verifier.actual(this.setup.pointWithStreetNameNoStreetNumberEdgeCandidatesNoDuplicates(),
+                new AddressPointMatchCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+    }
+
+    @Test
+    public void pointWithStreetNameNoStreetNumberPointCandidatesDuplicateNames()
+    {
+        this.verifier.actual(this.setup.pointWithStreetNameNoStreetNumberPointCandidatesDuplicateNames(),
+                new AddressPointMatchCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+    }
+
+    @Test
+    public void pointWithStreetNameNoStreetNumberEdgeCandidatesDuplicateNames()
+    {
+        this.verifier.actual(this.setup.pointWithStreetNameNoStreetNumberEdgeCandidatesDuplicateNames(),
+                new AddressPointMatchCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+    }
+
+    @Test
+    public void pointWithStreetNameNoStreetNumberNodeCandidatesBoxConfig()
+    {
+        this.verifier.actual(this.setup.pointWithStreetNameNoStreetNumberNodeCandidatesBoxConfig(), check);
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+    }
 
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/points/AddressPointMatchCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/points/AddressPointMatchCheckTest.java
@@ -15,7 +15,7 @@ public class AddressPointMatchCheckTest
 {
 
     private static final String JONES_STREET_NAME = "Jones";
-    private static final CharSequence JOHN_STREET_NAME = "John";
+    private static final String JOHN_STREET_NAME = "John";
     @Rule
     public AddressPointMatchCheckTestRule setup = new AddressPointMatchCheckTestRule();
 

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/points/AddressPointMatchCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/points/AddressPointMatchCheckTest.java
@@ -5,7 +5,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.openstreetmap.atlas.checks.configuration.ConfigurationResolver;
 import org.openstreetmap.atlas.checks.validation.verifier.ConsumerBasedExpectedCheckVerifier;
-import org.openstreetmap.atlas.utilities.configuration.Configuration;
 
 /**
  * Tests for {@link AddressPointMatchCheck}
@@ -14,9 +13,9 @@ import org.openstreetmap.atlas.utilities.configuration.Configuration;
  */
 public class AddressPointMatchCheckTest
 {
-    private final AddressPointMatchCheck check = new AddressPointMatchCheck(
-            ConfigurationResolver.inlineConfiguration(
-                    "{\"AddressPointMatchCheck\":{\"bounds.size\":100.0"));
+
+    private static final String JONES_STREET_NAME = "Jones";
+    private static final CharSequence JOHN_STREET_NAME = "John";
     @Rule
     public AddressPointMatchCheckTestRule setup = new AddressPointMatchCheckTestRule();
 
@@ -42,7 +41,8 @@ public class AddressPointMatchCheckTest
     @Test
     public void pointWithStreetNameNoStreetNumberPointCandidatesNoDuplicates()
     {
-        this.verifier.actual(this.setup.pointWithStreetNameNoStreetNumberPointCandidatesNoDuplicates(),
+        this.verifier.actual(
+                this.setup.pointWithStreetNameNoStreetNumberPointCandidatesNoDuplicates(),
                 new AddressPointMatchCheck(ConfigurationResolver.emptyConfiguration()));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
     }
@@ -50,7 +50,8 @@ public class AddressPointMatchCheckTest
     @Test
     public void pointWithStreetNameNoStreetNumberEdgeCandidatesNoDuplicates()
     {
-        this.verifier.actual(this.setup.pointWithStreetNameNoStreetNumberEdgeCandidatesNoDuplicates(),
+        this.verifier.actual(
+                this.setup.pointWithStreetNameNoStreetNumberEdgeCandidatesNoDuplicates(),
                 new AddressPointMatchCheck(ConfigurationResolver.emptyConfiguration()));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
     }
@@ -58,24 +59,24 @@ public class AddressPointMatchCheckTest
     @Test
     public void pointWithStreetNameNoStreetNumberPointCandidatesDuplicateNames()
     {
-        this.verifier.actual(this.setup.pointWithStreetNameNoStreetNumberPointCandidatesDuplicateNames(),
+        this.verifier.actual(
+                this.setup.pointWithStreetNameNoStreetNumberPointCandidatesDuplicateNames(),
                 new AddressPointMatchCheck(ConfigurationResolver.emptyConfiguration()));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+        this.verifier
+                .verify(flag -> Assert.assertTrue(flag.getInstructions().contains(JONES_STREET_NAME)
+                        && flag.getInstructions().contains(JOHN_STREET_NAME)));
     }
 
     @Test
     public void pointWithStreetNameNoStreetNumberEdgeCandidatesDuplicateNames()
     {
-        this.verifier.actual(this.setup.pointWithStreetNameNoStreetNumberEdgeCandidatesDuplicateNames(),
+        this.verifier.actual(
+                this.setup.pointWithStreetNameNoStreetNumberEdgeCandidatesDuplicateNames(),
                 new AddressPointMatchCheck(ConfigurationResolver.emptyConfiguration()));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
-    }
-
-    @Test
-    public void pointWithStreetNameNoStreetNumberNodeCandidatesBoxConfig()
-    {
-        this.verifier.actual(this.setup.pointWithStreetNameNoStreetNumberNodeCandidatesBoxConfig(), check);
-        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+        this.verifier.verify(
+                flag -> Assert.assertTrue(flag.getInstructions().contains(JONES_STREET_NAME)));
     }
 
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/points/AddressPointMatchCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/points/AddressPointMatchCheckTest.java
@@ -1,0 +1,5 @@
+package org.openstreetmap.atlas.checks.validation.points;
+
+public class AddressPointMatchCheckTest
+{
+}

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/points/AddressPointMatchCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/points/AddressPointMatchCheckTest.java
@@ -1,5 +1,19 @@
 package org.openstreetmap.atlas.checks.validation.points;
 
+import org.junit.Rule;
+import org.openstreetmap.atlas.checks.validation.verifier.ConsumerBasedExpectedCheckVerifier;
+
+/**
+ * Tests for {@link AddressPointMatchCheck}
+ *
+ * @author savannahostrowski
+ */
 public class AddressPointMatchCheckTest
 {
+    @Rule
+    public AddressPointMatchCheckTestRule setup = new AddressPointMatchCheckTestRule();
+
+    @Rule
+    public ConsumerBasedExpectedCheckVerifier verifier = new ConsumerBasedExpectedCheckVerifier();
+
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/points/AddressPointMatchCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/points/AddressPointMatchCheckTestRule.java
@@ -1,6 +1,12 @@
 package org.openstreetmap.atlas.checks.validation.points;
 
+import org.openstreetmap.atlas.geography.atlas.Atlas;
 import org.openstreetmap.atlas.utilities.testing.CoreTestRule;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Edge;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Loc;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Node;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Point;
 
 /**
  * {@link AddressPointMatchCheckTest} data generator
@@ -10,6 +16,83 @@ import org.openstreetmap.atlas.utilities.testing.CoreTestRule;
 
 public class AddressPointMatchCheckTestRule extends CoreTestRule
 {
+    private static final String TEST_1 = "37.3314171,-122.0304871";
+    private static final String TEST_2 = "37.331547, -122.031065";
+    private static final String TEST_3 = "37.331614, -122.030593";
+    private static final String TEST_4 = "37.331272, -122.031280";
+    private static final String TEST_5 = "37.331135, -122.030980";
 
+    @TestAtlas(points = { @Point(coordinates = @Loc(value = TEST_1), tags = { "addr:housenumber=20",
+            "addr:street=Smith" }) })
+    private Atlas pointWithStreetNameStreetNumber;
 
+    @TestAtlas(points = {
+            @Point(coordinates = @Loc(value = TEST_1), tags = { "addr:housenumber=20" }) })
+    private Atlas pointWithStreetNameNoStreetNumberNoCandidates;
+
+    @TestAtlas(points = {
+            @Point(coordinates = @Loc(value = TEST_1), tags = { "addr:housenumber=20" }),
+            @Point(coordinates = @Loc(value = TEST_2), tags = { "addr:housenumber=25",
+                    "addr:street=Smith" }) })
+    private Atlas pointWithStreetNameNoStreetNumberPointCandidatesNoDuplicates;
+
+    @TestAtlas(points = {
+            @Point(coordinates = @Loc(value = TEST_1), tags = { "addr:housenumber=20" }),
+
+    }, nodes = { @Node(coordinates = @Loc(value = TEST_2)),
+            @Node(coordinates = @Loc(value = TEST_3)) }, edges = { @Edge(coordinates = {
+                    @Loc(value = TEST_2), @Loc(value = TEST_3) }, tags = { "name=Smith" }), })
+    private Atlas pointWithStreetNameNoStreetNumberEdgeCandidatesNoDuplicates;
+
+    @TestAtlas(points = {
+            @Point(coordinates = @Loc(value = TEST_1), tags = { "addr:housenumber=20" }),
+            @Point(coordinates = @Loc(value = TEST_2), tags = { "addr:housenumber=20",
+                    "addr:street=Jones" }),
+            @Point(coordinates = @Loc(value = TEST_3), tags = { "addr:housenumber=20",
+                    "addr:street=Jones" }),
+            @Point(coordinates = @Loc(value = TEST_4), tags = { "addr:housenumber=20",
+                    "addr:street=John" }) })
+    private Atlas pointWithStreetNameNoStreetNumberPointCandidatesDuplicateNames;
+
+    @TestAtlas(points = { @Point(id = "1234", coordinates = @Loc(value = TEST_1), tags = {
+            "addr:housenumber=20" }),
+
+    }, nodes = { @Node(coordinates = @Loc(value = TEST_2)),
+            @Node(coordinates = @Loc(value = TEST_3)), @Node(coordinates = @Loc(value = TEST_4)),
+            @Node(coordinates = @Loc(value = TEST_5)), }, edges = {
+                    @Edge(coordinates = { @Loc(value = TEST_2), @Loc(value = TEST_3) }, tags = {
+                            "name=Jones" }),
+                    @Edge(coordinates = { @Loc(value = TEST_4), @Loc(value = TEST_5) }, tags = {
+                            "name=Jones" }) })
+    private Atlas pointWithStreetNameNoStreetNumberEdgeCandidatesDuplicateNames;
+
+    public Atlas pointWithStreetNameStreetNumber()
+    {
+        return pointWithStreetNameStreetNumber;
+    }
+
+    public Atlas pointWithStreetNameNoStreetNumberNoCandidates()
+    {
+        return pointWithStreetNameNoStreetNumberNoCandidates;
+    }
+
+    public Atlas pointWithStreetNameNoStreetNumberPointCandidatesNoDuplicates()
+    {
+        return pointWithStreetNameNoStreetNumberPointCandidatesNoDuplicates;
+    }
+
+    public Atlas pointWithStreetNameNoStreetNumberEdgeCandidatesNoDuplicates()
+    {
+        return pointWithStreetNameNoStreetNumberEdgeCandidatesNoDuplicates;
+    }
+
+    public Atlas pointWithStreetNameNoStreetNumberPointCandidatesDuplicateNames()
+    {
+        return pointWithStreetNameNoStreetNumberPointCandidatesDuplicateNames;
+    }
+
+    public Atlas pointWithStreetNameNoStreetNumberEdgeCandidatesDuplicateNames()
+    {
+        return pointWithStreetNameNoStreetNumberEdgeCandidatesDuplicateNames;
+    }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/points/AddressPointMatchCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/points/AddressPointMatchCheckTestRule.java
@@ -1,5 +1,15 @@
 package org.openstreetmap.atlas.checks.validation.points;
 
-public class AddressPointMatchCheckTestRule
+import org.openstreetmap.atlas.utilities.testing.CoreTestRule;
+
+/**
+ * {@link AddressPointMatchCheckTest} data generator
+ *
+ * @author savannahostrowski
+ */
+
+public class AddressPointMatchCheckTestRule extends CoreTestRule
 {
+
+
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/points/AddressPointMatchCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/points/AddressPointMatchCheckTestRule.java
@@ -1,0 +1,5 @@
+package org.openstreetmap.atlas.checks.validation.points;
+
+public class AddressPointMatchCheckTestRule
+{
+}


### PR DESCRIPTION
This check identifies Point objects in OSM that have a specified street number (addr:housenumber) 
but no specified street name (addr:street). No specified street name refers to either having a null
value for the street name key, or no street name key present at all.

This pull request includes: all check logic, unit tests, and documentation.

Pre and post analysis documents to come!