### PR TITLE
AddressPointMatch Check

### DIFF
--- a/config/configuration.json
+++ b/config/configuration.json
@@ -15,6 +15,16 @@
   "OrphanNodeCheck": {
 
   },
+  "AddressPointMatchCheck": {
+    "bounds.size": 150.0,
+    "challenge": {
+      "description": "Tasks contain nodes which either have no street name or incorrect street names",
+      "blurb": "Nodes without street names, or with incorrect street names",
+      "instruction": "Open your favorite editor and edit the node street names",
+      "difficulty": "EASY",
+      "defaultPriority": "LOW"
+    }
+  },
   "AreasWithHighwayTagCheck":{
     "tag.filters":"highway->!pedestrian&area->!yes",
     "challenge":{

--- a/docs/checks/addressPointMatch.md
+++ b/docs/checks/addressPointMatch.md
@@ -1,0 +1,110 @@
+# Address Point Match Check
+
+#### Description
+This check identifies Point objects in OSM that have a specified street number (addr:housenumber) 
+but no specified street name (addr:street). No specified street name refers to either having a null
+value for the street name key, or no street name key present at all.
+
+#### Live Example
+The following examples illustrate two cases where a Point has a street number but no street name
+in its tags.
+1) This Point [id:977597085](https://www.openstreetmap.org/node/977597085) has a street number but 
+no street name specified in the address.
+2) This Point [id:4552330391](https://www.openstreetmap.org/node/4552330391) has a street number but
+no street name specified in the address.
+
+#### Code Review
+In [Atlas](https://github.com/osmlab/atlas), OSM elements are represented as Edges, Points, Lines, 
+Nodes & Relations; in our case, we’re are looking at [Points](https://github.com/osmlab/atlas/blob/dev/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Point.java)
+with specified street numbers but no street name.
+
+Our first goal is to validate the incoming Atlas object. Valid features for this check will satisfy
+the following conditions:
+* Must be a valid Point object
+* Must have a street number tag not equal to null
+* Must have a street name tag equal to null OR not have the street name key present at all
+
+```java
+ @Override
+    public boolean validCheckForObject(final AtlasObject object)
+    {
+        // Object is an instance of Point
+        return object instanceof Point
+                // And has a street number specified
+                && object.getTag(ADDRESS_STREET_NUMBER_KEY).isPresent()
+                // And if the street name key has a value of null
+                && (!object.getTag(POINT_STREET_NAME_KEY).isPresent()
+                    // Or if the street name key is not present
+                    || !object.getTags().containsKey(POINT_STREET_NAME_KEY));
+    }
+```
+
+After the preliminary filtering of features, we need to find candidates for populating each feature's
+missing street name. We do this by drawing a bounding box, leveraging the [`boxAround()`](https://github.com/osmlab/atlas/blob/dev/src/main/java/org/openstreetmap/atlas/geography/Location.java), 
+around the Point of interest using a configurable bounds size parameter. This value is set to a 
+default of 150 meters. Using these bounds, we can consider other Points that fall inside the bounds 
+that have a specified street number and street name using [`pointsWithin()`](https://github.com/osmlab/atlas/blob/dev/src/main/java/org/openstreetmap/atlas/geography/atlas/Atlas.java).
+If there are no other Points found within this bounding box, we next look at edges within or which 
+intersect with our bounding box using [`edgesIntersecting()`](https://github.com/osmlab/atlas/blob/dev/src/main/java/org/openstreetmap/atlas/geography/atlas/Atlas.java).
+If there are no Points or Edges within or intersecting our bounds, we still flag the problematic
+Point feature but with a specific instruction message indicating that no candidate street names were found.
+Otherwise, we flag the Point and list a Set of unique candidate street names in the instructions.
+
+```java
+ @Override
+    protected Optional<CheckFlag> flag(final AtlasObject object)
+    {
+        final Point point = (Point) object;
+        // Get a bounding box around the Point of interest
+        final Rectangle box = point.getLocation().boxAround(boundsSize);
+
+        // Get all Points inside the bounding box
+        Iterable<Point> interiorPoints = point.getAtlas().pointsWithin(box);
+        // Convert the Iterable into a Stream for filtering
+        Stream<Point> pointStream = StreamSupport.stream(interiorPoints.spliterator(), false);
+        // Remove Points that have null as their street name as they cannot be candidates for
+        // a street for the Point of interest
+        Set<Point> points = pointStream.filter(interiorPoint -> interiorPoint.getTag(POINT_STREET_NAME_KEY).isPresent())
+                .collect(Collectors.toSet());
+
+        // Get all Edges that intersect or are contained within the bounding box
+        Iterable<Edge> interiorEdges = point.getAtlas().edgesIntersecting(box);
+        // Convert the Iterable into a Stream for filtering
+        Stream<Edge> edgeStream = StreamSupport.stream(interiorEdges.spliterator(), false);
+        // Remove Edge that have null as their street name as they cannot be candidates for
+        // a street for the Point of interest
+        Set<Edge> edges = edgeStream.filter(interiorEdge -> interiorEdge.getTag(EDGE_STREET_NAME_KEY).isPresent())
+                .collect(Collectors.toSet());
+
+        Set<String> streetNameList = new HashSet<>();
+
+        // If there are no Points or Edges in the bounding box
+        if (points.isEmpty() && edges.isEmpty())
+        {
+            // Flag Point with instruction indicating that there are are no suggestions
+            return Optional.of(this.createFlag(point,
+                    this.getLocalizedInstruction(1, point.getOsmIdentifier())));
+        }
+        // If there are Points in the bounding box
+        else if (!points.isEmpty())
+        {
+            // Add all interior Point street names to the list of candidate street names
+            points.forEach(interiorPoint -> streetNameList
+                    .add(interiorPoint.getTags().get(POINT_STREET_NAME_KEY)));
+
+        }
+        // If there are Edges intersecting or contained by the bounding box
+        else
+        {
+            // Add all interior Edge street names to the list of candidate street names
+            edges.forEach(interiorEdge -> streetNameList
+                    .add(interiorEdge.getTags().get(EDGE_STREET_NAME_KEY)));
+        }
+
+        return Optional.of(this.createFlag(point,
+                this.getLocalizedInstruction(0, point.getOsmIdentifier(), streetNameList)));
+    }
+```
+
+To learn more about the code, please look at the comments in the source code for the check.
+[AddressPointMatchCheck.java](../../src/main/java/org/openstreetmap/atlas/checks/validation/points/AddressPointMatchCheck.java)

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/points/AddressPointMatchCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/points/AddressPointMatchCheck.java
@@ -1,0 +1,136 @@
+package org.openstreetmap.atlas.checks.validation.points;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import org.openstreetmap.atlas.checks.base.BaseCheck;
+import org.openstreetmap.atlas.checks.flag.CheckFlag;
+import org.openstreetmap.atlas.geography.Rectangle;
+import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
+import org.openstreetmap.atlas.geography.atlas.items.Edge;
+import org.openstreetmap.atlas.geography.atlas.items.Point;
+import org.openstreetmap.atlas.tags.AddressHousenumberTag;
+import org.openstreetmap.atlas.tags.AddressStreetTag;
+import org.openstreetmap.atlas.tags.names.NameTag;
+import org.openstreetmap.atlas.utilities.configuration.Configuration;
+import org.openstreetmap.atlas.utilities.scalars.Distance;
+
+/**
+ * Tests for {@link AddressPointMatchCheck}
+ *
+ * @author savannahostrowski
+ */
+
+public class AddressPointMatchCheck extends BaseCheck
+{
+    private static final long serialVersionUID = 1L;
+    public static final String NO_STREET_NAME_POINT_INSTRUCTIONS = "This node, {0,number,#}, has "
+            + "no street name specified in the address. The street name should likely "
+            + "be one of {1}. These names were derived from nearby Points.";
+    public static final String NO_STREET_NAME_EDGE_INSTRUCTIONS = "This node, {0,number,#}, has "
+            + "no street name specified in the address. The street name should likely "
+            + "be one of {1}. These names were derived from nearby Edges.";
+    public static final String NO_SUGGESTED_NAMES_INSTRUCTIONS = "This node, {0,number,#}, has "
+            + "no street name specified in the address. No suggestions names were found.";
+    private static final List<String> FALLBACK_INSTRUCTIONS = Arrays.asList(
+            NO_STREET_NAME_POINT_INSTRUCTIONS, NO_STREET_NAME_EDGE_INSTRUCTIONS,
+            NO_SUGGESTED_NAMES_INSTRUCTIONS);
+    private static final String ADDRESS_STREET_NUMBER_KEY = AddressHousenumberTag.KEY;
+    private static final String POINT_STREET_NAME_KEY = AddressStreetTag.KEY;
+    private static final String EDGE_STREET_NAME_KEY = NameTag.KEY;
+    private static final double BOUNDS_SIZE_DEFAULT = 150.0;
+
+    private final Distance boundsSize;
+
+    @Override
+    protected List<String> getFallbackInstructions()
+    {
+        return FALLBACK_INSTRUCTIONS;
+    }
+
+    public AddressPointMatchCheck(final Configuration configuration)
+    {
+        super(configuration);
+        this.boundsSize = Distance.meters(
+                (Double) configurationValue(configuration, "bounds.size", BOUNDS_SIZE_DEFAULT));
+    }
+
+    @Override
+    public boolean validCheckForObject(final AtlasObject object)
+    {
+        // Object is an instance of Point
+        return object instanceof Point
+                // And has a street number specified
+                && object.getTag(ADDRESS_STREET_NUMBER_KEY).isPresent()
+                // And if the street name key has a value of null
+                && (!object.getTag(POINT_STREET_NAME_KEY).isPresent()
+                        // Or if the street name key is not present
+                        || !object.getTags().containsKey(POINT_STREET_NAME_KEY));
+    }
+
+    /**
+     * This is the actual function that will check to see whether the object needs to be flagged.
+     *
+     * @param object
+     *            the atlas object supplied by the Atlas-Checks framework for evaluation
+     * @return an optional {@link CheckFlag} object that
+     */
+    @Override
+    protected Optional<CheckFlag> flag(final AtlasObject object)
+    {
+        final Point point = (Point) object;
+        // Get a bounding box around the Point of interest
+        final Rectangle box = point.getLocation().boxAround(boundsSize);
+
+        // Get all Points inside the bounding box
+        final Iterable<Point> interiorPoints = point.getAtlas().pointsWithin(box);
+        // Convert the Iterable into a Stream for filtering, remove Points that have null as their
+        // street name as they cannot be candidates for a street for the Point of interest
+        final Set<Point> points = StreamSupport.stream(interiorPoints.spliterator(), false)
+                .filter(interiorPoint -> interiorPoint.getTag(POINT_STREET_NAME_KEY).isPresent())
+                .collect(Collectors.toSet());
+
+        // Get all Edges that intersect or are contained within the bounding box
+        final Iterable<Edge> interiorEdges = point.getAtlas().edgesIntersecting(box);
+        // Convert the Iterable into a Stream for filtering, remove Edge that have null as their
+        // street name as they cannot be candidates for a street for the Point of interest
+        final Set<Edge> edges = StreamSupport.stream(interiorEdges.spliterator(), false)
+                .filter(interiorEdge -> interiorEdge.getTag(EDGE_STREET_NAME_KEY).isPresent())
+                .collect(Collectors.toSet());
+
+        final Set<String> streetNameList = new HashSet<>();
+
+        // If there are no Points or Edges in the bounding box
+        if (points.isEmpty() && edges.isEmpty())
+        {
+            // Flag Point with instruction indicating that there are are no suggestions
+            return Optional.of(this.createFlag(point,
+                    this.getLocalizedInstruction(2, point.getOsmIdentifier())));
+        }
+        // If there are Points in the bounding box
+        else if (!points.isEmpty())
+        {
+            // Add all interior Point street names to the list of candidate street names
+            points.forEach(interiorPoint -> streetNameList
+                    .add(interiorPoint.getTags().get(POINT_STREET_NAME_KEY)));
+            return Optional.of(this.createFlag(point,
+                    this.getLocalizedInstruction(0, point.getOsmIdentifier(), streetNameList)));
+
+        }
+        // If there are Edges intersecting or contained by the bounding box
+        else
+        {
+            // Add all interior Edge street names to the list of candidate street names
+            edges.forEach(interiorEdge -> streetNameList
+                    .add(interiorEdge.getTags().get(EDGE_STREET_NAME_KEY)));
+            return Optional.of(this.createFlag(point,
+                    this.getLocalizedInstruction(1, point.getOsmIdentifier(), streetNameList)));
+        }
+
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/points/AddressPointMatchCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/points/AddressPointMatchCheckTest.java
@@ -1,0 +1,82 @@
+package org.openstreetmap.atlas.checks.validation.points;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.openstreetmap.atlas.checks.configuration.ConfigurationResolver;
+import org.openstreetmap.atlas.checks.validation.verifier.ConsumerBasedExpectedCheckVerifier;
+
+/**
+ * Tests for {@link AddressPointMatchCheck}
+ *
+ * @author savannahostrowski
+ */
+public class AddressPointMatchCheckTest
+{
+
+    private static final String JONES_STREET_NAME = "Jones";
+    private static final String JOHN_STREET_NAME = "John";
+    @Rule
+    public AddressPointMatchCheckTestRule setup = new AddressPointMatchCheckTestRule();
+
+    @Rule
+    public ConsumerBasedExpectedCheckVerifier verifier = new ConsumerBasedExpectedCheckVerifier();
+
+    @Test
+    public void pointWithStreetNameStreetNumber()
+    {
+        this.verifier.actual(this.setup.pointWithStreetNameStreetNumber(),
+                new AddressPointMatchCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+
+    @Test
+    public void pointWithStreetNameNoStreetNumberNoCandidates()
+    {
+        this.verifier.actual(this.setup.pointWithStreetNameNoStreetNumberNoCandidates(),
+                new AddressPointMatchCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+    }
+
+    @Test
+    public void pointWithStreetNameNoStreetNumberPointCandidatesNoDuplicates()
+    {
+        this.verifier.actual(
+                this.setup.pointWithStreetNameNoStreetNumberPointCandidatesNoDuplicates(),
+                new AddressPointMatchCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+    }
+
+    @Test
+    public void pointWithStreetNameNoStreetNumberEdgeCandidatesNoDuplicates()
+    {
+        this.verifier.actual(
+                this.setup.pointWithStreetNameNoStreetNumberEdgeCandidatesNoDuplicates(),
+                new AddressPointMatchCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+    }
+
+    @Test
+    public void pointWithStreetNameNoStreetNumberPointCandidatesDuplicateNames()
+    {
+        this.verifier.actual(
+                this.setup.pointWithStreetNameNoStreetNumberPointCandidatesDuplicateNames(),
+                new AddressPointMatchCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+        this.verifier
+                .verify(flag -> Assert.assertTrue(flag.getInstructions().contains(JONES_STREET_NAME)
+                        && flag.getInstructions().contains(JOHN_STREET_NAME)));
+    }
+
+    @Test
+    public void pointWithStreetNameNoStreetNumberEdgeCandidatesDuplicateNames()
+    {
+        this.verifier.actual(
+                this.setup.pointWithStreetNameNoStreetNumberEdgeCandidatesDuplicateNames(),
+                new AddressPointMatchCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+        this.verifier.verify(
+                flag -> Assert.assertTrue(flag.getInstructions().contains(JONES_STREET_NAME)));
+    }
+
+}

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/points/AddressPointMatchCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/points/AddressPointMatchCheckTestRule.java
@@ -1,0 +1,98 @@
+package org.openstreetmap.atlas.checks.validation.points;
+
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.utilities.testing.CoreTestRule;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Edge;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Loc;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Node;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Point;
+
+/**
+ * {@link AddressPointMatchCheckTest} data generator
+ *
+ * @author savannahostrowski
+ */
+
+public class AddressPointMatchCheckTestRule extends CoreTestRule
+{
+    private static final String TEST_1 = "37.3314171,-122.0304871";
+    private static final String TEST_2 = "37.331547, -122.031065";
+    private static final String TEST_3 = "37.331614, -122.030593";
+    private static final String TEST_4 = "37.331272, -122.031280";
+    private static final String TEST_5 = "37.331135, -122.030980";
+
+    @TestAtlas(points = { @Point(coordinates = @Loc(value = TEST_1), tags = { "addr:housenumber=20",
+            "addr:street=Smith" }) })
+    private Atlas pointWithStreetNameStreetNumber;
+
+    @TestAtlas(points = {
+            @Point(coordinates = @Loc(value = TEST_1), tags = { "addr:housenumber=20" }) })
+    private Atlas pointWithStreetNameNoStreetNumberNoCandidates;
+
+    @TestAtlas(points = {
+            @Point(coordinates = @Loc(value = TEST_1), tags = { "addr:housenumber=20" }),
+            @Point(coordinates = @Loc(value = TEST_2), tags = { "addr:housenumber=25",
+                    "addr:street=Smith" }) })
+    private Atlas pointWithStreetNameNoStreetNumberPointCandidatesNoDuplicates;
+
+    @TestAtlas(points = {
+            @Point(coordinates = @Loc(value = TEST_1), tags = { "addr:housenumber=20" }),
+
+    }, nodes = { @Node(coordinates = @Loc(value = TEST_2)),
+            @Node(coordinates = @Loc(value = TEST_3)) }, edges = { @Edge(coordinates = {
+                    @Loc(value = TEST_2), @Loc(value = TEST_3) }, tags = { "name=Smith" }), })
+    private Atlas pointWithStreetNameNoStreetNumberEdgeCandidatesNoDuplicates;
+
+    @TestAtlas(points = {
+            @Point(coordinates = @Loc(value = TEST_1), tags = { "addr:housenumber=20" }),
+            @Point(coordinates = @Loc(value = TEST_2), tags = { "addr:housenumber=20",
+                    "addr:street=Jones" }),
+            @Point(coordinates = @Loc(value = TEST_3), tags = { "addr:housenumber=20",
+                    "addr:street=Jones" }),
+            @Point(coordinates = @Loc(value = TEST_4), tags = { "addr:housenumber=20",
+                    "addr:street=John" }) })
+    private Atlas pointWithStreetNameNoStreetNumberPointCandidatesDuplicateNames;
+
+    @TestAtlas(points = { @Point(id = "1234", coordinates = @Loc(value = TEST_1), tags = {
+            "addr:housenumber=20" }),
+
+    }, nodes = { @Node(coordinates = @Loc(value = TEST_2)),
+            @Node(coordinates = @Loc(value = TEST_3)), @Node(coordinates = @Loc(value = TEST_4)),
+            @Node(coordinates = @Loc(value = TEST_5)), }, edges = {
+                    @Edge(coordinates = { @Loc(value = TEST_2), @Loc(value = TEST_3) }, tags = {
+                            "name=Jones" }),
+                    @Edge(coordinates = { @Loc(value = TEST_4), @Loc(value = TEST_5) }, tags = {
+                            "name=Jones" }) })
+    private Atlas pointWithStreetNameNoStreetNumberEdgeCandidatesDuplicateNames;
+
+    public Atlas pointWithStreetNameStreetNumber()
+    {
+        return pointWithStreetNameStreetNumber;
+    }
+
+    public Atlas pointWithStreetNameNoStreetNumberNoCandidates()
+    {
+        return pointWithStreetNameNoStreetNumberNoCandidates;
+    }
+
+    public Atlas pointWithStreetNameNoStreetNumberPointCandidatesNoDuplicates()
+    {
+        return pointWithStreetNameNoStreetNumberPointCandidatesNoDuplicates;
+    }
+
+    public Atlas pointWithStreetNameNoStreetNumberEdgeCandidatesNoDuplicates()
+    {
+        return pointWithStreetNameNoStreetNumberEdgeCandidatesNoDuplicates;
+    }
+
+    public Atlas pointWithStreetNameNoStreetNumberPointCandidatesDuplicateNames()
+    {
+        return pointWithStreetNameNoStreetNumberPointCandidatesDuplicateNames;
+    }
+
+    public Atlas pointWithStreetNameNoStreetNumberEdgeCandidatesDuplicateNames()
+    {
+        return pointWithStreetNameNoStreetNumberEdgeCandidatesDuplicateNames;
+    }
+}


### PR DESCRIPTION
This check identifies Point objects in OSM that have a specified street number (addr:housenumber)
but no specified street name (addr:street). No specified street name refers to either having a null
value for the street name key, or no street name key present at all.

This pull request includes: all check logic, unit tests, and documentation.

**This PR should be identical to the original PR opened for this request but with the commits squashed**