### PR TITLE
One Member Relation Check

### DIFF
--- a/config/configuration.json
+++ b/config/configuration.json
@@ -108,6 +108,14 @@
       "tags":"highway"
     }
   },
+  "OneMemberRelationCheck": {
+    "challenge": {
+      "description": "Tasks containing relations with only one member.",
+      "blurb": "One Member Relations",
+      "instruction": "Correct the relation to add necessary members",
+      "difficulty": "HARD"
+    }
+  },
   "RoundaboutClosedLoopCheck": {
     "challenge": {
       "description": "A roundabout should be formed by one-way edges with no dead-end nodes.",

--- a/docs/checks/oneMemberRelationCheck.md
+++ b/docs/checks/oneMemberRelationCheck.md
@@ -27,19 +27,16 @@ Relation objects. Therefore, we use:
         }
 ```
 
-After the preliminary filtering of features, we get the members of that relation, get the member
-entity type, and then collect them into a Set. Using this Set, we can check how many members it contains.
-If the Set is of size = 1, then we flag this relation.
+After the preliminary filtering of features, we get the members of that relation.
+If the members is of size = 1, then we flag this relation.
 
 
 ```java
-    @Override
+     @Override
         protected Optional<CheckFlag> flag(final AtlasObject object) {
             Relation relation = (Relation) object;
-            Set<AtlasObject> members = relation.members().stream()
-                    .map(RelationMember::getEntity).collect(Collectors.toSet());
-            if (members.size() == 1) {
-                return Optional.of(createFlag(members,
+            if (relation.members().size() == 1) {
+                return Optional.of(createFlag(relation,
                         this.getLocalizedInstruction(0, relation.getOsmIdentifier())));
             }
             return Optional.empty();

--- a/docs/checks/oneMemberRelationCheck.md
+++ b/docs/checks/oneMemberRelationCheck.md
@@ -1,0 +1,52 @@
+# Roundabout Valence Check
+
+#### Description
+
+This check identifies relations that only contain one member. 
+
+//// TO DO  - add information about why we know that one member relations should be flagged
+as designated by OSM ////
+
+#### Live Example
+The following examples illustrate two cases where a Relation contains only one member.
+
+//// TO DO - add examples ////
+
+#### Code Review
+
+In [Atlas](https://github.com/osmlab/atlas), OSM elements are represented as Edges, Points, Lines, 
+Nodes & Relations; in our case, we’re working with [Relations](https://github.com/osmlab/atlas/blob/dev/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Relation.java).
+
+Our first goal is to validate the incoming Atlas Object. We use some preliminary filtering to target
+Relation objects. Therefore, we use:
+* Must be a Relation
+
+```java
+    @Override
+        public boolean validCheckForObject(final AtlasObject object) {
+            return object instanceof Relation;
+        }
+```
+
+After the preliminary filtering of features, we get the members of that relation, get the member
+entity type, and then collect them into a Set. Using this Set, we can check how many members it contains.
+If the Set is of size = 1, then we flag this relation.
+
+
+```java
+    @Override
+        protected Optional<CheckFlag> flag(final AtlasObject object) {
+            Relation relation = (Relation) object;
+            Set<AtlasObject> members = relation.members().stream()
+                    .map(RelationMember::getEntity).collect(Collectors.toSet());
+            if (members.size() == 1) {
+                return Optional.of(createFlag(members,
+                        this.getLocalizedInstruction(0, relation.getOsmIdentifier())));
+            }
+            return Optional.empty();
+        }
+```
+
+
+To learn more about the code, please look at the comments in the source code for the check.
+[OneMemberRelationCheck.java](../../src/main/java/org/openstreetmap/atlas/checks/validation/relations/OneMemberRelationCheck.java)

--- a/docs/checks/oneMemberRelationCheck.md
+++ b/docs/checks/oneMemberRelationCheck.md
@@ -9,7 +9,7 @@ is a multi-purpose data structure that documents a relationship between two or m
 #### Live Example
 The following examples illustrate two cases where a Relation contains only one member.
 1) This relation [id:4646212](https://www.openstreetmap.org/relation/4646212) has only one member.
-2) This relation [id:7691824](ttps://www.openstreetmap.org/relation/7691824) has only one member.
+2) This relation [id:7691824](https://www.openstreetmap.org/relation/7691824) has only one member.
 
 #### Code Review
 

--- a/docs/checks/oneMemberRelationCheck.md
+++ b/docs/checks/oneMemberRelationCheck.md
@@ -1,11 +1,10 @@
-# Roundabout Valence Check
+# One Member Relation Check
 
 #### Description
 
-This check identifies relations that only contain one member. 
-
-//// TO DO  - add information about why we know that one member relations should be flagged
-as designated by OSM ////
+This check identifies relations that only contain one member. In OSM, a [Relation](https://wiki.openstreetmap.org/wiki/Elements#Relation)
+is a multi-purpose data structure that documents a relationship between two or more data elements 
+(nodes, ways, and/or other relations).
 
 #### Live Example
 The following examples illustrate two cases where a Relation contains only one member.

--- a/docs/checks/oneMemberRelationCheck.md
+++ b/docs/checks/oneMemberRelationCheck.md
@@ -8,8 +8,8 @@ is a multi-purpose data structure that documents a relationship between two or m
 
 #### Live Example
 The following examples illustrate two cases where a Relation contains only one member.
-
-//// TO DO - add examples ////
+1) This relation [id:4646212](https://www.openstreetmap.org/relation/4646212) has only one member.
+2) This relation [id:7691824](ttps://www.openstreetmap.org/relation/7691824) has only one member.
 
 #### Code Review
 

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/relations/OneMemberRelationCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/relations/OneMemberRelationCheck.java
@@ -12,6 +12,7 @@ import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
 import org.openstreetmap.atlas.geography.atlas.items.Relation;
 import org.openstreetmap.atlas.geography.atlas.items.RelationMember;
 import org.openstreetmap.atlas.geography.atlas.items.RelationMemberList;
+import org.openstreetmap.atlas.tags.RelationTypeTag;
 import org.openstreetmap.atlas.utilities.configuration.Configuration;
 
 /**
@@ -46,7 +47,24 @@ public class OneMemberRelationCheck extends BaseCheck
     @Override
     protected Optional<CheckFlag> flag(final AtlasObject object) {
         Relation relation = (Relation) object;
-        if (relation.members().size() == 1) {
+        boolean flag = false;
+        // If the relation is a multipolygon
+        if (relation.isMultiPolygon()) {
+            // If there are members with the role:inner
+            final boolean isInner = relation.members().stream()
+                    .anyMatch(member ->
+                            member.getRole().equalsIgnoreCase(RelationTypeTag.MULTIPOLYGON_ROLE_INNER));
+
+            // If the only member of the relation has the role:inner
+            if ( isInner && relation.members().size() == 1) {
+                flag = true;
+            }
+        // If the relation has only one member
+        } else if (relation.members().size() == 1) {
+            flag = true;
+        }
+
+        if (flag) {
             return Optional.of(createFlag(relation,
                     this.getLocalizedInstruction(0, relation.getOsmIdentifier())));
         }

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/relations/OneMemberRelationCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/relations/OneMemberRelationCheck.java
@@ -11,6 +11,7 @@ import org.openstreetmap.atlas.checks.flag.CheckFlag;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
 import org.openstreetmap.atlas.geography.atlas.items.Relation;
 import org.openstreetmap.atlas.geography.atlas.items.RelationMember;
+import org.openstreetmap.atlas.geography.atlas.items.RelationMemberList;
 import org.openstreetmap.atlas.utilities.configuration.Configuration;
 
 /**
@@ -45,10 +46,8 @@ public class OneMemberRelationCheck extends BaseCheck
     @Override
     protected Optional<CheckFlag> flag(final AtlasObject object) {
         Relation relation = (Relation) object;
-        Set<AtlasObject> members = relation.members().stream()
-                .map(RelationMember::getEntity).collect(Collectors.toSet());
-        if (members.size() == 1) {
-            return Optional.of(createFlag(members,
+        if (relation.members().size() == 1) {
+            return Optional.of(createFlag(relation,
                     this.getLocalizedInstruction(0, relation.getOsmIdentifier())));
         }
         return Optional.empty();

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/relations/OneMemberRelationCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/relations/OneMemberRelationCheck.java
@@ -9,6 +9,7 @@ import org.openstreetmap.atlas.checks.base.BaseCheck;
 import org.openstreetmap.atlas.checks.flag.CheckFlag;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
 import org.openstreetmap.atlas.geography.atlas.items.Relation;
+import org.openstreetmap.atlas.geography.atlas.items.RelationMember;
 import org.openstreetmap.atlas.tags.RelationTypeTag;
 import org.openstreetmap.atlas.utilities.configuration.Configuration;
 
@@ -73,7 +74,7 @@ public class OneMemberRelationCheck extends BaseCheck
         {
             this.markAsFlagged(relation.getOsmIdentifier());
             return Optional.of(createFlag(
-                    relation.members().stream().map(member -> member.getEntity())
+                    relation.members().stream().map(RelationMember::getEntity)
                             .collect(Collectors.toSet()),
                     this.getLocalizedInstruction(0, relation.getOsmIdentifier())));
         }

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/relations/OneMemberRelationCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/relations/OneMemberRelationCheck.java
@@ -1,6 +1,7 @@
 package org.openstreetmap.atlas.checks.validation.relations;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -25,8 +26,8 @@ public class OneMemberRelationCheck extends BaseCheck
     public static final String OMR_INSTRUCTIONS = "This relation, {0,number,#}, contains only "
             + "one member.";
 
-    private static final List<String> FALLBACK_INSTRUCTIONS = Arrays.asList(
-            OMR_INSTRUCTIONS);
+    private static final List<String> FALLBACK_INSTRUCTIONS = Collections
+            .singletonList(OMR_INSTRUCTIONS);
 
     @Override
     protected List<String> getFallbackInstructions()
@@ -47,19 +48,21 @@ public class OneMemberRelationCheck extends BaseCheck
     @Override
     protected Optional<CheckFlag> flag(final AtlasObject object) {
         Relation relation = (Relation) object;
+        // Initialize a flag that will be flipped if the relation is found to be problematic
         boolean flag = false;
+
         // If the relation is a multipolygon
         if (relation.isMultiPolygon()) {
-            // If there are members with the role:inner
+            // Determine if there are members with the role:inner
             final boolean isInner = relation.members().stream()
                     .anyMatch(member ->
                             member.getRole().equalsIgnoreCase(RelationTypeTag.MULTIPOLYGON_ROLE_INNER));
 
-            // If the only member of the relation has the role:inner
-            if ( isInner && relation.members().size() == 1) {
+            // If the only member of the relation has the role:inner then we want to flag the relation
+            if (isInner && relation.members().size() == 1) {
                 flag = true;
             }
-        // If the relation has only one member
+        // If the relation has only one member and is not a multi-polygon
         } else if (relation.members().size() == 1) {
             flag = true;
         }

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/relations/OneMemberRelationCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/relations/OneMemberRelationCheck.java
@@ -1,0 +1,56 @@
+package org.openstreetmap.atlas.checks.validation.relations;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.openstreetmap.atlas.checks.base.BaseCheck;
+import org.openstreetmap.atlas.checks.flag.CheckFlag;
+import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
+import org.openstreetmap.atlas.geography.atlas.items.Relation;
+import org.openstreetmap.atlas.geography.atlas.items.RelationMember;
+import org.openstreetmap.atlas.utilities.configuration.Configuration;
+
+/**
+ * This check flags {@link Relation}s which contain only one member.
+ *
+ * @author savannahostrowski
+ */
+public class OneMemberRelationCheck extends BaseCheck
+{
+    public static final String OMR_INSTRUCTIONS = "This {0} is the only member "
+            + " in a relation.";
+
+    private static final List<String> FALLBACK_INSTRUCTIONS = Arrays.asList(
+            OMR_INSTRUCTIONS);
+
+    @Override
+    protected List<String> getFallbackInstructions()
+    {
+        return FALLBACK_INSTRUCTIONS;
+    }
+
+    public OneMemberRelationCheck(final Configuration configuration)
+    {
+        super(configuration);
+    }
+
+    @Override
+    public boolean validCheckForObject(final AtlasObject object) {
+        return object instanceof Relation;
+    }
+
+    @Override
+    protected Optional<CheckFlag> flag(final AtlasObject object) {
+        Relation relation = (Relation) object;
+        Set<AtlasObject> members = relation.members().stream()
+                .map(RelationMember::getEntity).collect(Collectors.toSet());
+        if (members.size() == 1) {
+            return Optional.of(createFlag(members,
+                    this.getLocalizedInstruction(0, relation.getOsmIdentifier())));
+        }
+        return Optional.empty();
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/relations/OneMemberRelationCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/relations/OneMemberRelationCheck.java
@@ -20,8 +20,8 @@ import org.openstreetmap.atlas.utilities.configuration.Configuration;
  */
 public class OneMemberRelationCheck extends BaseCheck
 {
-    public static final String OMR_INSTRUCTIONS = "This {0} is the only member "
-            + " in a relation.";
+    public static final String OMR_INSTRUCTIONS = "This relation, {0,number,#}, contains only "
+            + "one member.";
 
     private static final List<String> FALLBACK_INSTRUCTIONS = Arrays.asList(
             OMR_INSTRUCTIONS);

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/relations/OneMemberRelationCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/relations/OneMemberRelationCheckTest.java
@@ -1,0 +1,38 @@
+package org.openstreetmap.atlas.checks.validation.relations;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.openstreetmap.atlas.checks.configuration.ConfigurationResolver;
+import org.openstreetmap.atlas.checks.validation.verifier.ConsumerBasedExpectedCheckVerifier;
+
+/**
+ * Tests for {@link OneMemberRelationCheck}
+ *
+ * @author savannahostrowski
+ */
+public class OneMemberRelationCheckTest
+{
+    private static final OneMemberRelationCheck check = new OneMemberRelationCheck(
+            ConfigurationResolver.emptyConfiguration());
+
+    @Rule
+    public OneMemberRelationCheckTestRule setup = new OneMemberRelationCheckTestRule();
+
+    @Rule
+    public ConsumerBasedExpectedCheckVerifier verifier = new ConsumerBasedExpectedCheckVerifier();
+
+    @Test
+    public void testValidRelation()
+    {
+        this.verifier.actual(this.setup.getValidRelation(), check);
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+
+    @Test
+    public void testOneMemberRelation()
+    {
+        this.verifier.actual(this.setup.getOneMemberRelation(), check);
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/relations/OneMemberRelationCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/relations/OneMemberRelationCheckTest.java
@@ -57,5 +57,4 @@ public class OneMemberRelationCheckTest
         this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
     }
 
-
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/relations/OneMemberRelationCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/relations/OneMemberRelationCheckTest.java
@@ -35,4 +35,27 @@ public class OneMemberRelationCheckTest
         this.verifier.actual(this.setup.getOneMemberRelation(), check);
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
     }
+
+    @Test
+    public void testOneMemberRelationMultipolygonInner()
+    {
+        this.verifier.actual(this.setup.getOneMemberRelationMultipolygonInner(), check);
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+    }
+
+    @Test
+    public void testOneMemberRelationMultipolygonOuter()
+    {
+        this.verifier.actual(this.setup.getOneMemberRelationMultipolygonOuter(), check);
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+
+    @Test
+    public void testValidRelationMultipolygon()
+    {
+        this.verifier.actual(this.setup.getValidRelationMultipolygon(), check);
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+
+
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/relations/OneMemberRelationCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/relations/OneMemberRelationCheckTestRule.java
@@ -56,11 +56,75 @@ public class OneMemberRelationCheckTestRule extends CoreTestRule
                     tags = { "restriction=no_u_turn" }) })
     private Atlas oneMemberRelation;
 
+    @TestAtlas(
+            // nodes
+            nodes = { @Node(id = "1", coordinates = @Loc(value = ONE)),
+                    @Node(id = "2", coordinates = @Loc(value = TWO)) },
+            // edges
+            edges = {
+                    @Edge(id = "12", coordinates = { @Loc(value = ONE),
+                            @Loc(value = TWO) }, tags = { "highway=road" }) },
+            // relations
+            relations = { @Relation(id = "123", members = {
+                    @Member(id = "12", type = "edge", role = RelationTypeTag.MULTIPOLYGON_ROLE_INNER)},
+                    tags = { "restriction=no_u_turn", "type=multipolygon" }) })
+    private Atlas oneMemberRelationMultipolygonInner;
+
+    @TestAtlas(
+            // nodes
+            nodes = { @Node(id = "1", coordinates = @Loc(value = ONE)),
+                    @Node(id = "2", coordinates = @Loc(value = TWO)) },
+            // edges
+            edges = {
+                    @Edge(id = "12", coordinates = { @Loc(value = ONE),
+                            @Loc(value = TWO) }, tags = { "highway=road" }) },
+            // relations
+            relations = { @Relation(id = "123", members = {
+                    @Member(id = "12", type = "edge", role = RelationTypeTag.MULTIPOLYGON_ROLE_OUTER)},
+                    tags = { "restriction=no_u_turn", "type=multipolygon" }) })
+    private Atlas oneMemberRelationMultipolygonOuter;
+
+    @TestAtlas(
+            // nodes
+            nodes = { @Node(id = "1", coordinates = @Loc(value = ONE)),
+                    @Node(id = "2", coordinates = @Loc(value = TWO)),
+                    @Node(id = "3", coordinates = @Loc(value = THREE)) },
+            // edges
+            edges = {
+                    @Edge(id = "12", coordinates = { @Loc(value = ONE),
+                            @Loc(value = TWO) }, tags = { "highway=road" }),
+                    @Edge(id = "23", coordinates = { @Loc(value = TWO),
+                            @Loc(value = THREE) }, tags = { "highway=road" }),
+                    @Edge(id = "31", coordinates = { @Loc(value = THREE),
+                            @Loc(value = ONE) }, tags = { "highway=road" }) },
+            // relations
+            relations = { @Relation(id = "123", members = {
+                    @Member(id = "12", type = "edge", role = RelationTypeTag.MULTIPOLYGON_ROLE_INNER),
+                    @Member(id = "2", type = "node", role = RelationTypeTag.MULTIPOLYGON_ROLE_OUTER),
+                    @Member(id = "23", type = "edge", role = RelationTypeTag.MULTIPOLYGON_ROLE_OUTER) },
+                    tags = { "restriction=no_u_turn", "type=multipolygon" }) })
+    private Atlas validRelationMultipolygon;
+
     public Atlas getValidRelation() {
         return this.validRelation;
     }
 
     public Atlas getOneMemberRelation() {
         return this.oneMemberRelation;
+    }
+
+    public Atlas getOneMemberRelationMultipolygonInner()
+    {
+        return oneMemberRelationMultipolygonInner;
+    }
+
+    public Atlas getOneMemberRelationMultipolygonOuter()
+    {
+        return oneMemberRelationMultipolygonOuter;
+    }
+
+    public Atlas getValidRelationMultipolygon()
+    {
+        return validRelationMultipolygon;
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/relations/OneMemberRelationCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/relations/OneMemberRelationCheckTestRule.java
@@ -114,16 +114,16 @@ public class OneMemberRelationCheckTestRule extends CoreTestRule
 
     public Atlas getOneMemberRelationMultipolygonInner()
     {
-        return oneMemberRelationMultipolygonInner;
+        return this.oneMemberRelationMultipolygonInner;
     }
 
     public Atlas getOneMemberRelationMultipolygonOuter()
     {
-        return oneMemberRelationMultipolygonOuter;
+        return this.oneMemberRelationMultipolygonOuter;
     }
 
     public Atlas getValidRelationMultipolygon()
     {
-        return validRelationMultipolygon;
+        return this.validRelationMultipolygon;
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/relations/OneMemberRelationCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/relations/OneMemberRelationCheckTestRule.java
@@ -1,0 +1,66 @@
+package org.openstreetmap.atlas.checks.validation.relations;
+
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.tags.RelationTypeTag;
+import org.openstreetmap.atlas.utilities.testing.CoreTestRule;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Edge;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Loc;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Node;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Relation;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Relation.Member;
+
+/**
+ * {@link OneMemberRelationCheckTest} data generator
+ *
+ * @author savannahostrowski
+ */
+public class OneMemberRelationCheckTestRule extends CoreTestRule
+{
+    private static final String ONE = "18.4360044, -71.7194204";
+    private static final String TWO = "18.4360737, -71.6970306";
+    private static final String THREE = "18.4273807, -71.7052283";
+
+    @TestAtlas(
+            // nodes
+            nodes = { @Node(id = "1", coordinates = @Loc(value = ONE)),
+                    @Node(id = "2", coordinates = @Loc(value = TWO)),
+                    @Node(id = "3", coordinates = @Loc(value = THREE)) },
+            // edges
+            edges = {
+                    @Edge(id = "12", coordinates = { @Loc(value = ONE),
+                            @Loc(value = TWO) }, tags = { "highway=road" }),
+                    @Edge(id = "23", coordinates = { @Loc(value = TWO),
+                            @Loc(value = THREE) }, tags = { "highway=road" }),
+                    @Edge(id = "31", coordinates = { @Loc(value = THREE),
+                            @Loc(value = ONE) }, tags = { "highway=road" }) },
+            // relations
+            relations = { @Relation(id = "123", members = {
+                    @Member(id = "12", type = "edge", role = RelationTypeTag.RESTRICTION_ROLE_FROM),
+                    @Member(id = "2", type = "node", role = RelationTypeTag.RESTRICTION_ROLE_VIA),
+                    @Member(id = "23", type = "edge", role = RelationTypeTag.RESTRICTION_ROLE_TO) },
+                    tags = { "restriction=no_u_turn" }) })
+    private Atlas validRelation;
+
+    @TestAtlas(
+            // nodes
+            nodes = { @Node(id = "1", coordinates = @Loc(value = ONE)),
+                    @Node(id = "2", coordinates = @Loc(value = TWO)) },
+            // edges
+            edges = {
+                    @Edge(id = "12", coordinates = { @Loc(value = ONE),
+                            @Loc(value = TWO) }, tags = { "highway=road" }) },
+            // relations
+            relations = { @Relation(id = "123", members = {
+                    @Member(id = "12", type = "edge", role = RelationTypeTag.RESTRICTION_ROLE_FROM)},
+                    tags = { "restriction=no_u_turn" }) })
+    private Atlas oneMemberRelation;
+
+    public Atlas getValidRelation() {
+        return this.validRelation;
+    }
+
+    public Atlas getOneMemberRelation() {
+        return this.oneMemberRelation;
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/relations/OneMemberRelationCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/relations/OneMemberRelationCheckTestRule.java
@@ -38,8 +38,8 @@ public class OneMemberRelationCheckTestRule extends CoreTestRule
             relations = { @Relation(id = "123", members = {
                     @Member(id = "12", type = "edge", role = RelationTypeTag.RESTRICTION_ROLE_FROM),
                     @Member(id = "2", type = "node", role = RelationTypeTag.RESTRICTION_ROLE_VIA),
-                    @Member(id = "23", type = "edge", role = RelationTypeTag.RESTRICTION_ROLE_TO) },
-                    tags = { "restriction=no_u_turn" }) })
+                    @Member(id = "23", type = "edge", role = RelationTypeTag.RESTRICTION_ROLE_TO) }, tags = {
+                            "restriction=no_u_turn" }) })
     private Atlas validRelation;
 
     @TestAtlas(
@@ -47,13 +47,12 @@ public class OneMemberRelationCheckTestRule extends CoreTestRule
             nodes = { @Node(id = "1", coordinates = @Loc(value = ONE)),
                     @Node(id = "2", coordinates = @Loc(value = TWO)) },
             // edges
-            edges = {
-                    @Edge(id = "12", coordinates = { @Loc(value = ONE),
-                            @Loc(value = TWO) }, tags = { "highway=road" }) },
+            edges = { @Edge(id = "12", coordinates = { @Loc(value = ONE),
+                    @Loc(value = TWO) }, tags = { "highway=road" }) },
             // relations
             relations = { @Relation(id = "123", members = {
-                    @Member(id = "12", type = "edge", role = RelationTypeTag.RESTRICTION_ROLE_FROM)},
-                    tags = { "restriction=no_u_turn" }) })
+                    @Member(id = "12", type = "edge", role = RelationTypeTag.RESTRICTION_ROLE_FROM) }, tags = {
+                            "restriction=no_u_turn" }) })
     private Atlas oneMemberRelation;
 
     @TestAtlas(
@@ -61,13 +60,12 @@ public class OneMemberRelationCheckTestRule extends CoreTestRule
             nodes = { @Node(id = "1", coordinates = @Loc(value = ONE)),
                     @Node(id = "2", coordinates = @Loc(value = TWO)) },
             // edges
-            edges = {
-                    @Edge(id = "12", coordinates = { @Loc(value = ONE),
-                            @Loc(value = TWO) }, tags = { "highway=road" }) },
+            edges = { @Edge(id = "12", coordinates = { @Loc(value = ONE),
+                    @Loc(value = TWO) }, tags = { "highway=road" }) },
             // relations
             relations = { @Relation(id = "123", members = {
-                    @Member(id = "12", type = "edge", role = RelationTypeTag.MULTIPOLYGON_ROLE_INNER)},
-                    tags = { "restriction=no_u_turn", "type=multipolygon" }) })
+                    @Member(id = "12", type = "edge", role = RelationTypeTag.MULTIPOLYGON_ROLE_INNER) }, tags = {
+                            "restriction=no_u_turn", "type=multipolygon" }) })
     private Atlas oneMemberRelationMultipolygonInner;
 
     @TestAtlas(
@@ -75,13 +73,12 @@ public class OneMemberRelationCheckTestRule extends CoreTestRule
             nodes = { @Node(id = "1", coordinates = @Loc(value = ONE)),
                     @Node(id = "2", coordinates = @Loc(value = TWO)) },
             // edges
-            edges = {
-                    @Edge(id = "12", coordinates = { @Loc(value = ONE),
-                            @Loc(value = TWO) }, tags = { "highway=road" }) },
+            edges = { @Edge(id = "12", coordinates = { @Loc(value = ONE),
+                    @Loc(value = TWO) }, tags = { "highway=road" }) },
             // relations
             relations = { @Relation(id = "123", members = {
-                    @Member(id = "12", type = "edge", role = RelationTypeTag.MULTIPOLYGON_ROLE_OUTER)},
-                    tags = { "restriction=no_u_turn", "type=multipolygon" }) })
+                    @Member(id = "12", type = "edge", role = RelationTypeTag.MULTIPOLYGON_ROLE_OUTER) }, tags = {
+                            "restriction=no_u_turn", "type=multipolygon" }) })
     private Atlas oneMemberRelationMultipolygonOuter;
 
     @TestAtlas(
@@ -101,15 +98,17 @@ public class OneMemberRelationCheckTestRule extends CoreTestRule
             relations = { @Relation(id = "123", members = {
                     @Member(id = "12", type = "edge", role = RelationTypeTag.MULTIPOLYGON_ROLE_INNER),
                     @Member(id = "2", type = "node", role = RelationTypeTag.MULTIPOLYGON_ROLE_OUTER),
-                    @Member(id = "23", type = "edge", role = RelationTypeTag.MULTIPOLYGON_ROLE_OUTER) },
-                    tags = { "restriction=no_u_turn", "type=multipolygon" }) })
+                    @Member(id = "23", type = "edge", role = RelationTypeTag.MULTIPOLYGON_ROLE_OUTER) }, tags = {
+                            "restriction=no_u_turn", "type=multipolygon" }) })
     private Atlas validRelationMultipolygon;
 
-    public Atlas getValidRelation() {
+    public Atlas getValidRelation()
+    {
         return this.validRelation;
     }
 
-    public Atlas getOneMemberRelation() {
+    public Atlas getOneMemberRelation()
+    {
         return this.oneMemberRelation;
     }
 


### PR DESCRIPTION
The OneMemberRelation Check flags Relations that only have one Member. 

This pull request contains logic, documentation, configuration, and unit tests.

This PR includes flag logic, documentation, configuration, and unit tests.

**OSM Examples:**
https://www.openstreetmap.org/relation/6077987
https://www.openstreetmap.org/relation/7214599