### PR TITLE
Sink Island Check Enhancements

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheck.java
@@ -1,15 +1,25 @@
 package org.openstreetmap.atlas.checks.validation.linear.edges;
 
-import java.util.*;
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Queue;
+import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.openstreetmap.atlas.checks.atlas.predicates.TagPredicates;
 import org.openstreetmap.atlas.checks.base.BaseCheck;
 import org.openstreetmap.atlas.checks.flag.CheckFlag;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
 import org.openstreetmap.atlas.geography.atlas.items.Edge;
-import org.openstreetmap.atlas.tags.*;
+import org.openstreetmap.atlas.tags.AerowayTag;
+import org.openstreetmap.atlas.tags.AmenityTag;
+import org.openstreetmap.atlas.tags.HighwayTag;
+import org.openstreetmap.atlas.tags.RouteTag;
+import org.openstreetmap.atlas.tags.SyntheticBoundaryNodeTag;
 import org.openstreetmap.atlas.tags.annotations.validation.Validators;
 import org.openstreetmap.atlas.utilities.configuration.Configuration;
 
@@ -27,8 +37,8 @@ public class SinkIslandCheck extends BaseCheck<Long>
     private static final long TREE_SIZE_DEFAULT = 50;
     private static final List<String> FALLBACK_INSTRUCTIONS = Collections
             .singletonList("Road is impossible to get out of.");
-    private static final String MOTORCYCLE_PARKING_AMENITY = "motorcycle_parking";
-    private static final String PARKING_ENTRANCE_AMENITY = "parking_entrance";
+    private static final String MOTORCYCLE_PARKING_AMENITY = "MOTORCYCLE_PARKING";
+    private static final String PARKING_ENTRANCE_AMENITY = "PARKING_ENTRANCE";
     private static final List<String> amenityTypesToExclude = Arrays.asList(
             AmenityTag.PARKING.toString(), AmenityTag.PARKING_SPACE.toString(),
             MOTORCYCLE_PARKING_AMENITY, PARKING_ENTRANCE_AMENITY);
@@ -168,7 +178,7 @@ public class SinkIslandCheck extends BaseCheck<Long>
                 // Ignore any airport taxiways and runways, as these often create a sink island
                 && !Validators.isOfType(object, AerowayTag.class, AerowayTag.TAXIWAY,
                         AerowayTag.RUNWAY)
-                && hasAmenityTagToExclude(object)
+                && !hasAmenityTagToExclude(object)
                 // Ignore edges that have been way sectioned at the border, as has high probability
                 // of creating a false positive due to the sectioning of the way
                 && !(SyntheticBoundaryNodeTag.isBoundaryNode(((Edge) object).end())
@@ -180,7 +190,6 @@ public class SinkIslandCheck extends BaseCheck<Long>
     }
 
     private boolean hasAmenityTagToExclude(final AtlasObject object) {
-        return amenityTypesToExclude.stream()
-                .anyMatch(type -> ((Edge) object).end().getTag(AmenityTag.KEY).equals(type));
+        return amenityTypesToExclude.contains(((Edge) object).end().getTag(AmenityTag.KEY).get().toUpperCase());
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheckTest.java
@@ -33,4 +33,13 @@ public class SinkIslandCheckTest
                 ConfigurationResolver.inlineConfiguration("{\"SinkIslandCheck.tree.size\": 3}")));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
     }
+
+    @Test
+    public void testSingleEdgeWithAmenity()
+    {
+        this.verifier.actual(this.setup.getSingleEdgeWithAmenityAtlas(), new SinkIslandCheck(
+                ConfigurationResolver.inlineConfiguration("{\"SinkIslandCheck.tree.size\": 3}")));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheckTestRule.java
@@ -59,6 +59,13 @@ public class SinkIslandCheckTestRule extends CoreTestRule
                     @Loc(value = TEST_7) }, tags = { "highway=primary", "oneway=yes" }) })
     private Atlas singleEdgeAtlas;
 
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = TEST_6)),
+            @Node(coordinates = @Loc(value = TEST_7), tags = { "amenity=parking" }) },
+
+            edges = { @Edge(id = "360978519000003", coordinates = { @Loc(value = TEST_6),
+                    @Loc(value = TEST_7) }, tags = { "highway=primary", "oneway=yes" }) })
+    private Atlas singleEdgeWithAmenityAtlas;
+
     public Atlas getSingleEdgeAtlas()
     {
         return this.singleEdgeAtlas;
@@ -67,5 +74,10 @@ public class SinkIslandCheckTestRule extends CoreTestRule
     public Atlas getTestAtlas()
     {
         return this.testAtlas;
+    }
+
+    public Atlas getSingleEdgeWithAmenityAtlas()
+    {
+        return this.singleEdgeWithAmenityAtlas;
     }
 }


### PR DESCRIPTION
The enhancements made to the Sink Island check filter out Ways from flagging candidates which contain an amenity tag with the value of either Parking, Parking Space, Motorcycle Parking, or Parking Entrance on the end node.